### PR TITLE
Avoid unnecessary Vec allocation in `get_string_utf_length_as_long`

### DIFF
--- a/src/vm/jni/jni_env.rs
+++ b/src/vm/jni/jni_env.rs
@@ -31,6 +31,12 @@ use crate::vm::jni::static_fields_impl::{
     set_static_double_field, set_static_float_field, set_static_int_field, set_static_long_field,
     set_static_object_field, set_static_short_field,
 };
+use crate::vm::jni::static_methods_impl::{
+    call_static_boolean_method_a, call_static_byte_method_a, call_static_char_method_a,
+    call_static_double_method_a, call_static_float_method_a, call_static_int_method_a,
+    call_static_long_method_a, call_static_object_method_a, call_static_short_method_a,
+    call_static_void_method_a, get_static_method_id,
+};
 use crate::vm::jni::string_operations_impl::{
     get_string_chars, get_string_length, get_string_utf_chars, get_string_utf_length,
     get_string_utf_length_as_long, new_string, new_string_utf8, release_string_chars,
@@ -207,37 +213,26 @@ jni_stub!(CallNonvirtualDoubleMethodA(jobject, jclass, jmethodID, *const jvalue)
 jni_variadic_stub!(CallNonvirtualVoidMethod, CallNonvirtualVoidMethod_ptr, (jobject, jclass, jmethodID) -> ());
 jni_stub!(CallNonvirtualVoidMethodV(jobject, jclass, jmethodID, va_list) -> ());
 jni_stub!(CallNonvirtualVoidMethodA(jobject, jclass, jmethodID, *const jvalue) -> ());
-jni_stub!(GetStaticMethodID(jclass, *const c_char, *const c_char) -> jmethodID);
 jni_variadic_stub!(CallStaticObjectMethod, CallStaticObjectMethod_ptr, (jclass, jmethodID) -> jobject);
 jni_stub!(CallStaticObjectMethodV(jclass, jmethodID, va_list) -> jobject);
-jni_stub!(CallStaticObjectMethodA(jclass, jmethodID, *const jvalue) -> jobject);
 jni_variadic_stub!(CallStaticBooleanMethod, CallStaticBooleanMethod_ptr, (jclass, jmethodID) -> jboolean);
 jni_stub!(CallStaticBooleanMethodV(jclass, jmethodID, va_list) -> jboolean);
-jni_stub!(CallStaticBooleanMethodA(jclass, jmethodID, *const jvalue) -> jboolean);
 jni_variadic_stub!(CallStaticByteMethod, CallStaticByteMethod_ptr, (jclass, jmethodID) -> jbyte);
 jni_stub!(CallStaticByteMethodV(jclass, jmethodID, va_list) -> jbyte);
-jni_stub!(CallStaticByteMethodA(jclass, jmethodID, *const jvalue) -> jbyte);
 jni_variadic_stub!(CallStaticCharMethod, CallStaticCharMethod_ptr, (jclass, jmethodID) -> jchar);
 jni_stub!(CallStaticCharMethodV(jclass, jmethodID, va_list) -> jchar);
-jni_stub!(CallStaticCharMethodA(jclass, jmethodID, *const jvalue) -> jchar);
 jni_variadic_stub!(CallStaticShortMethod, CallStaticShortMethod_ptr, (jclass, jmethodID) -> jshort);
 jni_stub!(CallStaticShortMethodV(jclass, jmethodID, va_list) -> jshort);
-jni_stub!(CallStaticShortMethodA(jclass, jmethodID, *const jvalue) -> jshort);
 jni_variadic_stub!(CallStaticIntMethod, CallStaticIntMethod_ptr, (jclass, jmethodID) -> jint);
 jni_stub!(CallStaticIntMethodV(jclass, jmethodID, va_list) -> jint);
-jni_stub!(CallStaticIntMethodA(jclass, jmethodID, *const jvalue) -> jint);
 jni_variadic_stub!(CallStaticLongMethod, CallStaticLongMethod_ptr, (jclass, jmethodID) -> jlong);
 jni_stub!(CallStaticLongMethodV(jclass, jmethodID, va_list) -> jlong);
-jni_stub!(CallStaticLongMethodA(jclass, jmethodID, *const jvalue) -> jlong);
 jni_variadic_stub!(CallStaticFloatMethod, CallStaticFloatMethod_ptr, (jclass, jmethodID) -> jfloat);
 jni_stub!(CallStaticFloatMethodV(jclass, jmethodID, va_list) -> jfloat);
-jni_stub!(CallStaticFloatMethodA(jclass, jmethodID, *const jvalue) -> jfloat);
 jni_variadic_stub!(CallStaticDoubleMethod, CallStaticDoubleMethod_ptr, (jclass, jmethodID) -> jdouble);
 jni_stub!(CallStaticDoubleMethodV(jclass, jmethodID, va_list) -> jdouble);
-jni_stub!(CallStaticDoubleMethodA(jclass, jmethodID, *const jvalue) -> jdouble);
 jni_variadic_stub!(CallStaticVoidMethod, CallStaticVoidMethod_ptr, (jclass, jmethodID) -> ());
 jni_stub!(CallStaticVoidMethodV(jclass, jmethodID, va_list) -> ());
-jni_stub!(CallStaticVoidMethodA(jclass, jmethodID, *const jvalue) -> ());
 jni_stub!(RegisterNatives(jclass, *const JNINativeMethod, jint) -> jint);
 jni_stub!(UnregisterNatives(jclass) -> jint);
 jni_stub!(MonitorEnter(jobject) -> jint);
@@ -376,37 +371,37 @@ static VTABLE: Wrapper = {
     ni.v24.SetLongField = set_long_field;
     ni.v24.SetFloatField = set_float_field;
     ni.v24.SetDoubleField = set_double_field;
-    ni.v24.GetStaticMethodID = GetStaticMethodID;
+    ni.v24.GetStaticMethodID = get_static_method_id;
     ni.v24.CallStaticObjectMethod = CallStaticObjectMethod_ptr;
     ni.v24.CallStaticObjectMethodV = CallStaticObjectMethodV;
-    ni.v24.CallStaticObjectMethodA = CallStaticObjectMethodA;
+    ni.v24.CallStaticObjectMethodA = call_static_object_method_a;
     ni.v24.CallStaticBooleanMethod = CallStaticBooleanMethod_ptr;
     ni.v24.CallStaticBooleanMethodV = CallStaticBooleanMethodV;
-    ni.v24.CallStaticBooleanMethodA = CallStaticBooleanMethodA;
+    ni.v24.CallStaticBooleanMethodA = call_static_boolean_method_a;
     ni.v24.CallStaticByteMethod = CallStaticByteMethod_ptr;
     ni.v24.CallStaticByteMethodV = CallStaticByteMethodV;
-    ni.v24.CallStaticByteMethodA = CallStaticByteMethodA;
+    ni.v24.CallStaticByteMethodA = call_static_byte_method_a;
     ni.v24.CallStaticCharMethod = CallStaticCharMethod_ptr;
     ni.v24.CallStaticCharMethodV = CallStaticCharMethodV;
-    ni.v24.CallStaticCharMethodA = CallStaticCharMethodA;
+    ni.v24.CallStaticCharMethodA = call_static_char_method_a;
     ni.v24.CallStaticShortMethod = CallStaticShortMethod_ptr;
     ni.v24.CallStaticShortMethodV = CallStaticShortMethodV;
-    ni.v24.CallStaticShortMethodA = CallStaticShortMethodA;
+    ni.v24.CallStaticShortMethodA = call_static_short_method_a;
     ni.v24.CallStaticIntMethod = CallStaticIntMethod_ptr;
     ni.v24.CallStaticIntMethodV = CallStaticIntMethodV;
-    ni.v24.CallStaticIntMethodA = CallStaticIntMethodA;
+    ni.v24.CallStaticIntMethodA = call_static_int_method_a;
     ni.v24.CallStaticLongMethod = CallStaticLongMethod_ptr;
     ni.v24.CallStaticLongMethodV = CallStaticLongMethodV;
-    ni.v24.CallStaticLongMethodA = CallStaticLongMethodA;
+    ni.v24.CallStaticLongMethodA = call_static_long_method_a;
     ni.v24.CallStaticFloatMethod = CallStaticFloatMethod_ptr;
     ni.v24.CallStaticFloatMethodV = CallStaticFloatMethodV;
-    ni.v24.CallStaticFloatMethodA = CallStaticFloatMethodA;
+    ni.v24.CallStaticFloatMethodA = call_static_float_method_a;
     ni.v24.CallStaticDoubleMethod = CallStaticDoubleMethod_ptr;
     ni.v24.CallStaticDoubleMethodV = CallStaticDoubleMethodV;
-    ni.v24.CallStaticDoubleMethodA = CallStaticDoubleMethodA;
+    ni.v24.CallStaticDoubleMethodA = call_static_double_method_a;
     ni.v24.CallStaticVoidMethod = CallStaticVoidMethod_ptr;
     ni.v24.CallStaticVoidMethodV = CallStaticVoidMethodV;
-    ni.v24.CallStaticVoidMethodA = CallStaticVoidMethodA;
+    ni.v24.CallStaticVoidMethodA = call_static_void_method_a;
     ni.v24.GetStaticFieldID = get_static_field_id;
     ni.v24.GetStaticObjectField = get_static_object_field;
     ni.v24.GetStaticBooleanField = get_static_boolean_field;

--- a/src/vm/jni/jni_value.rs
+++ b/src/vm/jni/jni_value.rs
@@ -98,3 +98,13 @@ impl JNIValue for jdouble {
         StackValue::to_vec(&(self.to_bits() as i64))
     }
 }
+
+impl JNIValue for () {
+    fn from_vec(_v: &[i32]) -> Self {
+        ()
+    }
+
+    fn to_vec(&self) -> Vec<i32> {
+        vec![]
+    }
+}

--- a/src/vm/jni/mod.rs
+++ b/src/vm/jni/mod.rs
@@ -7,6 +7,7 @@ mod jni_value;
 mod object_fields_impl;
 mod object_operations_impl;
 mod static_fields_impl;
+mod static_methods_impl;
 mod string_operations_impl;
 mod utils;
 mod version_information_impl;

--- a/src/vm/jni/static_methods_impl.rs
+++ b/src/vm/jni/static_methods_impl.rs
@@ -79,7 +79,13 @@ fn invoke_static_method(
 ) -> Vec<i32> {
     let args_values = transform_args_to_vec(&method, args);
     Executor::invoke_static_method_jc(&klass, method.name_signature(), &args_values)
-        .expect("Failed to invoke static void method")
+        .unwrap_or_else(|e| {
+            panic!(
+                "Failed to invoke static method {}.{} ({e})",
+                klass.this_class_name(),
+                method.name_signature()
+            )
+        })
 }
 
 fn transform_args_to_vec(method: &Arc<JavaMethod>, args: *const jvalue) -> Vec<StackValueKind> {

--- a/src/vm/jni/static_methods_impl.rs
+++ b/src/vm/jni/static_methods_impl.rs
@@ -87,6 +87,14 @@ fn transform_args_to_vec(method: &Arc<JavaMethod>, args: *const jvalue) -> Vec<S
     let pt = md.parameter_types();
     let args_count = pt.len();
 
+    if args_count == 0 {
+        return vec![];
+    }
+
+    if args.is_null() {
+        panic!("Null pointer passed as arguments for method that expects {args_count} arguments");
+    }
+
     let args = unsafe { std::slice::from_raw_parts(args, args_count) };
     args.iter()
         .zip(pt.iter())

--- a/src/vm/jni/static_methods_impl.rs
+++ b/src/vm/jni/static_methods_impl.rs
@@ -1,0 +1,112 @@
+use crate::from_mutf8_ptr;
+use crate::vm::execution_engine::executor::Executor;
+use crate::vm::execution_engine::static_init::StaticInit;
+use crate::vm::helper::klass;
+use crate::vm::jni::jni_value::JNIValue;
+use crate::vm::method_area::java_class::JavaClass;
+use crate::vm::method_area::java_method::JavaMethod;
+use crate::vm::stack::stack_value::StackValueKind;
+use jdescriptor::TypeDescriptor;
+use jni_sys::{
+    jboolean, jbyte, jchar, jclass, jdouble, jfloat, jint, jlong, jmethodID, jobject, jshort,
+    jvalue, JNIEnv,
+};
+use std::ffi::c_char;
+use std::ptr::null_mut;
+use std::sync::Arc;
+
+pub(super) extern "system" fn get_static_method_id(
+    _env: *mut JNIEnv,
+    clazz: jclass,
+    name: *const c_char,
+    sig: *const c_char,
+) -> jmethodID {
+    let name_str = from_mutf8_ptr!(name).expect("Failed to convert method name from CESU-8");
+    let sig_str = from_mutf8_ptr!(sig).expect("Failed to convert method signature from CESU-8");
+    let klass = klass(clazz as i32).expect("Failed to get class from reference");
+    StaticInit::initialize_java_class(&klass)
+        .expect("Failed to initialize class before getting static method ID"); // todo: throw ExceptionInInitializerError here
+    let full_signature = format!("{}:{}", name_str, sig_str);
+
+    klass
+        .get_method_full(&full_signature)
+        .and_then(|(method_id, _method)| Some(method_id as jmethodID))
+        .unwrap_or(null_mut()) // todo: throw NoSuchMethodError here
+}
+
+macro_rules! get_static_method_a_impl {
+    ($name:ident, $jni_ty:ty) => {
+        pub(super) extern "system" fn $name(
+            env: *mut JNIEnv,
+            clazz: jclass,
+            method_id: jmethodID,
+            args: *const jvalue,
+        ) -> $jni_ty {
+            call_static_method_a::<$jni_ty>(env, clazz, method_id, args)
+        }
+    };
+}
+get_static_method_a_impl!(call_static_object_method_a, jobject);
+get_static_method_a_impl!(call_static_boolean_method_a, jboolean);
+get_static_method_a_impl!(call_static_byte_method_a, jbyte);
+get_static_method_a_impl!(call_static_char_method_a, jchar);
+get_static_method_a_impl!(call_static_short_method_a, jshort);
+get_static_method_a_impl!(call_static_int_method_a, jint);
+get_static_method_a_impl!(call_static_long_method_a, jlong);
+get_static_method_a_impl!(call_static_float_method_a, jfloat);
+get_static_method_a_impl!(call_static_double_method_a, jdouble);
+get_static_method_a_impl!(call_static_void_method_a, ());
+pub(super) extern "system" fn call_static_method_a<T: JNIValue>(
+    _env: *mut JNIEnv,
+    cls: jclass,
+    method_id: jmethodID,
+    args: *const jvalue,
+) -> T {
+    let method_index = method_id as i64;
+    let klass = klass(cls as i32).expect("Failed to get class from reference");
+    let method = klass
+        .get_method_by_index(method_index)
+        .expect("Failed to get method by ID for static void method call");
+
+    let raw = invoke_static_method(&klass, &method, args);
+    JNIValue::from_vec(&raw)
+}
+
+fn invoke_static_method(
+    klass: &Arc<JavaClass>,
+    method: &Arc<JavaMethod>,
+    args: *const jvalue,
+) -> Vec<i32> {
+    let args_values = transform_args_to_vec(&method, args);
+    Executor::invoke_static_method_jc(&klass, method.name_signature(), &args_values)
+        .expect("Failed to invoke static void method")
+}
+
+fn transform_args_to_vec(method: &Arc<JavaMethod>, args: *const jvalue) -> Vec<StackValueKind> {
+    let md = method.get_method_descriptor();
+    let pt = md.parameter_types();
+    let args_count = pt.len();
+
+    let args = unsafe { std::slice::from_raw_parts(args, args_count) };
+    args.iter()
+        .zip(pt.iter())
+        .map(|(arg, pt)| resolve_stack_kind_value(*arg, pt))
+        .collect::<Vec<_>>()
+}
+
+fn resolve_stack_kind_value(value: jvalue, type_descriptor: &TypeDescriptor) -> StackValueKind {
+    match type_descriptor {
+        TypeDescriptor::Boolean => (if unsafe { value.z } { 1 } else { 0 }).into(),
+        TypeDescriptor::Byte => (unsafe { value.b } as i32).into(),
+        TypeDescriptor::Char => (unsafe { value.c } as i32).into(),
+        TypeDescriptor::Short => (unsafe { value.s } as i32).into(),
+        TypeDescriptor::Integer => (unsafe { value.i } as i32).into(),
+        TypeDescriptor::Long => (unsafe { value.j } as i64).into(),
+        TypeDescriptor::Float => (unsafe { value.f } as f32).into(),
+        TypeDescriptor::Double => (unsafe { value.d } as f64).into(),
+        TypeDescriptor::Object(_) | TypeDescriptor::Array(_, _) => {
+            (unsafe { value.l } as i32).into()
+        }
+        TypeDescriptor::Void => panic!("Void type cannot be used as argument"),
+    }
+}

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -1,4 +1,3 @@
-use crate::from_mutf8_ptr;
 use crate::vm::execution_engine::executor::Executor;
 use crate::vm::heap::heap::HEAP;
 use crate::vm::jni::array_operations_impl::{
@@ -6,6 +5,7 @@ use crate::vm::jni::array_operations_impl::{
 };
 use crate::vm::method_area::loaded_classes::CLASSES;
 use crate::vm::system_native::string::get_raw_string_info;
+use crate::{from_mutf8_ptr, to_mutf8_data};
 use cesu8::to_java_cesu8;
 use jni_sys::{jboolean, jbyte, jchar, jint, jlong, jsize, jstring, JNIEnv, JNI_TRUE};
 use std::ffi::c_char;
@@ -175,9 +175,7 @@ pub(super) extern "system" fn get_string_utf_length_as_long(
         panic!("Invalid string reference"); // OpenJDK crashes here, why we shouldn't
     }
 
-    let raw_data = get_string_raw_data(string_ref);
-    let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
-    to_java_cesu8(&data).len() as jlong
+    to_mutf8_data!(string_ref).len() as jlong - 1
 }
 
 pub(super) extern "system" fn get_string_utf_length(_env: *mut JNIEnv, input: jstring) -> jint {
@@ -194,10 +192,7 @@ pub(super) extern "system" fn get_string_utf_chars(
         panic!("Invalid string reference: null");
     }
 
-    let raw_data = get_string_raw_data(string_ref);
-    let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
-    let mut mutf8_data = to_java_cesu8(&data).to_vec();
-    mutf8_data.push(0); // null terminator
+    let mutf8_data = to_mutf8_data!(string_ref);
     let boxed_slice = mutf8_data.into_boxed_slice();
     let raw_ptr = Box::into_raw(boxed_slice) as *const u8 as *const c_char;
 

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -175,7 +175,9 @@ pub(super) extern "system" fn get_string_utf_length_as_long(
         panic!("Invalid string reference"); // OpenJDK crashes here, why we shouldn't
     }
 
-    to_mutf8_data!(string_ref).len() as jlong - 1
+    let raw_data = get_string_raw_data(string_ref);
+    let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
+    to_java_cesu8(&data).len() as jlong
 }
 
 pub(super) extern "system" fn get_string_utf_length(_env: *mut JNIEnv, input: jstring) -> jint {

--- a/src/vm/jni/utils.rs
+++ b/src/vm/jni/utils.rs
@@ -8,3 +8,14 @@ macro_rules! from_mutf8_ptr {
         cesu8::from_java_cesu8(unsafe { CStr::from_ptr(ptr) }.to_bytes())
     }};
 }
+
+#[macro_export]
+macro_rules! to_mutf8_data {
+    ($string_ref:expr) => {{
+        let raw_data = get_string_raw_data($string_ref);
+        let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
+        let mut mutf8_data = to_java_cesu8(&data).to_vec();
+        mutf8_data.push(0); // null terminator
+        mutf8_data
+    }};
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3544,6 +3544,27 @@ objectFloatField: current value=3.14
 objectFloatField: new value=2.710000
 objectDoubleField: current value=3.141592653589793
 objectDoubleField: new value=2.7182818284590450
+
+=== Static Methods Demo ===
+objectMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticObjectMethodDemo -> I'm a result from Java!
+booleanMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticBooleanMethodDemo -> true
+byteMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticByteMethodDemo -> -128
+charMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticCharMethodDemo -> Ї
+shortMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticShortMethodDemo -> -32768
+intMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticIntMethodDemo -> -2000000000
+longMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticLongMethodDemo -> -9000000000000000000
+floatMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticFloatMethodDemo -> 2.710000
+doubleMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
+StaticDoubleMethodDemo -> 2.718282
+voidMethodToCall called with true, -128, Ї, -32768, -2000000000, -9000000000000000000, 3.140000104904, 3.141592653590, Hi
 "#
         ),
         r#"WARNING: A restricted method in java.lang.System has been called

--- a/tests/jni_test_lib/src/lib.rs
+++ b/tests/jni_test_lib/src/lib.rs
@@ -2,6 +2,7 @@ mod array_operations_demo;
 mod object_fields_demo;
 mod object_operations_demo;
 mod static_fields_demo;
+mod static_methods_demo;
 mod string_operations_demo;
 
 use jni::elements::ReleaseMode::NoCopyBack;

--- a/tests/jni_test_lib/src/static_methods_demo.rs
+++ b/tests/jni_test_lib/src/static_methods_demo.rs
@@ -1,0 +1,130 @@
+use jni::sys::{
+    jboolean, jbyte, jchar, jclass, jdouble, jfloat, jint, jlong, jmethodID, jobject, jshort,
+    jstring, jvalue, JNIEnv,
+};
+
+macro_rules! process_static_method_impl {
+    ($name:ident, $jni_ty:ty, $call_fn:ident) => {
+        #[no_mangle]
+        pub extern "system" fn $name(
+            env: *mut JNIEnv,
+            class: jclass,
+            method_name_ref: jstring,
+            signature_ref: jstring,
+            z: jboolean,
+            b: jbyte,
+            c: jchar,
+            s: jshort,
+            i: jint,
+            j: jlong,
+            f: jfloat,
+            d: jdouble,
+            l: jobject,
+        ) -> $jni_ty {
+            unsafe {
+                process_static_method_call::<$jni_ty>(
+                    env,
+                    class,
+                    method_name_ref,
+                    signature_ref,
+                    z,
+                    b,
+                    c,
+                    s,
+                    i,
+                    j,
+                    f,
+                    d,
+                    l,
+                    (*(*env)).v24.$call_fn,
+                )
+            }
+        }
+    };
+}
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticObjectMethodDemo,
+    jobject,
+    CallStaticObjectMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticBooleanMethodDemo,
+    jboolean,
+    CallStaticBooleanMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticByteMethodDemo,
+    jbyte,
+    CallStaticByteMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticCharMethodDemo,
+    jchar,
+    CallStaticCharMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticShortMethodDemo,
+    jshort,
+    CallStaticShortMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticIntMethodDemo,
+    jint,
+    CallStaticIntMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticLongMethodDemo,
+    jlong,
+    CallStaticLongMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticFloatMethodDemo,
+    jfloat,
+    CallStaticFloatMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticDoubleMethodDemo,
+    jdouble,
+    CallStaticDoubleMethodA
+);
+process_static_method_impl!(
+    Java_samples_javacore_loadlibrary_example_StaticMethodsDemo_StaticVoidMethodDemo,
+    (),
+    CallStaticVoidMethodA
+);
+unsafe fn process_static_method_call<T>(
+    env: *mut JNIEnv,
+    class: jclass,
+    method_name_ref: jstring,
+    signature_ref: jstring,
+    z: jboolean,
+    b: jbyte,
+    c: jchar,
+    s: jshort,
+    i: jint,
+    j: jlong,
+    f: jfloat,
+    d: jdouble,
+    l: jobject,
+    call_fn: unsafe extern "system" fn(*mut JNIEnv, jclass, jmethodID, *const jvalue) -> T,
+) -> T {
+    let method_name =
+        ((*(*env)).v24.GetStringUTFChars)(env, method_name_ref, std::ptr::null_mut());
+    let signature = ((*(*env)).v24.GetStringUTFChars)(env, signature_ref, std::ptr::null_mut());
+    let method_id = ((*(*env)).v24.GetStaticMethodID)(env, class, method_name, signature);
+    ((*(*env)).v24.ReleaseStringUTFChars)(env, signature_ref, signature);
+    ((*(*env)).v24.ReleaseStringUTFChars)(env, method_name_ref, method_name);
+
+    let args: Vec<jvalue> = vec![
+        jvalue { z },
+        jvalue { b },
+        jvalue { c },
+        jvalue { s },
+        jvalue { i },
+        jvalue { j },
+        jvalue { f },
+        jvalue { d },
+        jvalue { l },
+    ];
+    call_fn(env, class, method_id, args.as_ptr())
+}

--- a/tests/test_data/LoadLibraryExample.java
+++ b/tests/test_data/LoadLibraryExample.java
@@ -83,6 +83,7 @@ class LoadLibraryExample {
         ObjectOperationsDemo.runDemo();
         ObjectFieldDemo objectFieldDemo = new ObjectFieldDemo();
         objectFieldDemo.runDemo();
+        StaticMethodsDemo.runDemo();
     }
 }
 
@@ -574,5 +575,113 @@ class ObjectFieldDemo {
         System.out.print("objectDoubleField: ");
         processObjectDoubleField("objectDoubleField", "D", Math.E);
         System.out.printf("objectDoubleField: new value=%.16f%n", objectDoubleField);
+    }
+}
+
+class StaticMethodsDemo {
+    private static native Object StaticObjectMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native boolean StaticBooleanMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native byte StaticByteMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native char StaticCharMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native short StaticShortMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native int StaticIntMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native long StaticLongMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native float StaticFloatMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native double StaticDoubleMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+    private static native void StaticVoidMethodDemo(String methodName, String signature, boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l);
+
+    private static final String SIG_TMPL = "(ZBCSIJFDLjava/lang/Object;)%s";
+    private static final String MSG_TMPL = "%s called with %b, %d, %c, %d, %d, %d, %.12f, %.12f, %s%n";
+    private static final boolean Z = true;
+    private static final byte B = -128;
+    private static final char C = 'Ї';
+    private static final short S = -32768;
+    private static final int I = -2_000_000_000;
+    private static final long J = -9_000_000_000_000_000_000L;
+    private static final float F = 3.14f;
+    private static final double D = Math.PI;
+    private static final Object L = "Hi";
+
+    public static void runDemo() {
+        System.out.println();
+        System.out.println("=== Static Methods Demo ===");
+
+        Object objectResult = StaticObjectMethodDemo("objectMethodToCall", SIG_TMPL.formatted("Ljava/lang/Object;"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticObjectMethodDemo -> %s%n", objectResult);
+
+        boolean boolResult = StaticBooleanMethodDemo("booleanMethodToCall", SIG_TMPL.formatted("Z"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticBooleanMethodDemo -> %b%n", boolResult);
+
+        byte byteResult = StaticByteMethodDemo("byteMethodToCall", SIG_TMPL.formatted("B"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticByteMethodDemo -> %d%n", byteResult);
+
+        char charResult = StaticCharMethodDemo("charMethodToCall", SIG_TMPL.formatted("C"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticCharMethodDemo -> %c%n", charResult);
+
+        short shortResult = StaticShortMethodDemo("shortMethodToCall", SIG_TMPL.formatted("S"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticShortMethodDemo -> %d%n", shortResult);
+
+        int intResult = StaticIntMethodDemo("intMethodToCall", SIG_TMPL.formatted("I"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticIntMethodDemo -> %d%n", intResult);
+
+        long longResult = StaticLongMethodDemo("longMethodToCall", SIG_TMPL.formatted("J"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticLongMethodDemo -> %d%n", longResult);
+
+        float floatResult = StaticFloatMethodDemo("floatMethodToCall", SIG_TMPL.formatted("F"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticFloatMethodDemo -> %f%n", floatResult);
+
+        double doubleResult = StaticDoubleMethodDemo("doubleMethodToCall", SIG_TMPL.formatted("D"), Z, B, C, S, I, J, F, D, L);
+        System.out.printf("StaticDoubleMethodDemo -> %f%n", doubleResult);
+
+        StaticVoidMethodDemo("voidMethodToCall", SIG_TMPL.formatted("V"), Z, B, C, S, I, J, F, D, L);
+    }
+
+    private static Object objectMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "objectMethodToCall", z, b, c, s, i, j, f, d, l);
+        return "I'm a result from Java!";
+    }
+
+    private static boolean booleanMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "booleanMethodToCall", z, b, c, s, i, j, f, d, l);
+        return true;
+    }
+
+    private static byte byteMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "byteMethodToCall", z, b, c, s, i, j, f, d, l);
+        return -128;
+    }
+
+    private static char charMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "charMethodToCall", z, b, c, s, i, j, f, d, l);
+        return 'Ї';
+    }
+
+    private static short shortMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "shortMethodToCall", z, b, c, s, i, j, f, d, l);
+        return -32768;
+    }
+
+    private static int intMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "intMethodToCall", z, b, c, s, i, j, f, d, l);
+        return -2_000_000_000;
+    }
+
+    private static long longMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "longMethodToCall", z, b, c, s, i, j, f, d, l);
+        return -9_000_000_000_000_000_000L;
+    }
+
+    private static float floatMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "floatMethodToCall", z, b, c, s, i, j, f, d, l);
+        return 2.71f;
+    }
+
+    private static double doubleMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "doubleMethodToCall", z, b, c, s, i, j, f, d, l);
+        return Math.E;
+    }
+
+    private static void voidMethodToCall(boolean z, byte b, char c, short s, int i, long j, float f, double d, Object l) {
+        System.out.printf(MSG_TMPL, "voidMethodToCall", z, b, c, s, i, j, f, d, l);
     }
 }


### PR DESCRIPTION
`get_string_utf_length_as_long` was using `to_mutf8_data!` which always calls `.to_vec()` and appends a null terminator — allocating a `Vec<u8>` just to call `.len()` on it.

## Change

Compute the CESU-8 encoded length directly without materializing a `Vec`:

```rust
// Before
to_mutf8_data!(string_ref).len() as jlong - 1  // allocates Vec + null terminator

// After
let raw_data = get_string_raw_data(string_ref);
let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
to_java_cesu8(&data).len() as jlong  // Cow<[u8]>.len() — no forced allocation
```

`to_java_cesu8` returns `Cow<[u8]>`, so `.len()` avoids the heap allocation entirely when the data doesn't require re-encoding. The `to_mutf8_data!` macro remains in use only in `get_string_utf_chars`, where the full owned buffer is actually needed.