### PR TITLE
Implements the four remaining JNI string operations  

### DIFF
--- a/src/vm/jni/jni_env.rs
+++ b/src/vm/jni/jni_env.rs
@@ -48,9 +48,10 @@ use crate::vm::jni::static_methods_impl::{
     call_static_void_method_a, get_static_method_id,
 };
 use crate::vm::jni::string_operations_impl::{
-    get_string_chars, get_string_length, get_string_utf_chars, get_string_utf_length,
-    get_string_utf_length_as_long, new_string, new_string_utf8, release_string_chars,
-    release_string_utf_chars,
+    get_string_chars, get_string_critical, get_string_length, get_string_region,
+    get_string_utf_chars, get_string_utf_length, get_string_utf_length_as_long,
+    get_string_utf_region, new_string, new_string_utf8, release_string_chars,
+    release_string_critical, release_string_utf_chars,
 };
 use crate::vm::jni::version_information_impl::get_version;
 use jni_sys::{
@@ -226,12 +227,10 @@ jni_stub!(RegisterNatives(jclass, *const JNINativeMethod, jint) -> jint);
 jni_stub!(UnregisterNatives(jclass) -> jint);
 jni_stub!(MonitorEnter(jobject) -> jint);
 jni_stub!(MonitorExit(jobject) -> jint);
-jni_stub!(GetStringRegion(jstring, jsize, jsize, *mut jchar) -> ());
-jni_stub!(GetStringUTFRegion(jstring, jsize, jsize, *mut c_char) -> ());
+// GetStringRegion and GetStringUTFRegion are implemented in string_operations_impl.rs
 jni_stub!(GetPrimitiveArrayCritical(jarray, *mut jboolean) -> *mut c_void);
 jni_stub!(ReleasePrimitiveArrayCritical(jarray, *mut c_void, jint) -> ());
-jni_stub!(GetStringCritical(jstring, *mut jboolean) -> *const jchar);
-jni_stub!(ReleaseStringCritical(jstring, *const jchar) -> ());
+// GetStringCritical and ReleaseStringCritical are implemented in string_operations_impl.rs
 jni_stub!(NewWeakGlobalRef(jobject) -> jweak);
 jni_stub!(DeleteWeakGlobalRef(jweak) -> ());
 jni_stub!(NewDirectByteBuffer(*mut c_void, jlong) -> jobject);
@@ -467,12 +466,12 @@ static VTABLE: Wrapper = {
     ni.v24.MonitorEnter = MonitorEnter;
     ni.v24.MonitorExit = MonitorExit;
     ni.v24.GetJavaVM = get_java_vm;
-    ni.v24.GetStringRegion = GetStringRegion;
-    ni.v24.GetStringUTFRegion = GetStringUTFRegion;
+    ni.v24.GetStringRegion = get_string_region;
+    ni.v24.GetStringUTFRegion = get_string_utf_region;
     ni.v24.GetPrimitiveArrayCritical = GetPrimitiveArrayCritical;
     ni.v24.ReleasePrimitiveArrayCritical = ReleasePrimitiveArrayCritical;
-    ni.v24.GetStringCritical = GetStringCritical;
-    ni.v24.ReleaseStringCritical = ReleaseStringCritical;
+    ni.v24.GetStringCritical = get_string_critical;
+    ni.v24.ReleaseStringCritical = release_string_critical;
     ni.v24.NewWeakGlobalRef = NewWeakGlobalRef;
     ni.v24.DeleteWeakGlobalRef = DeleteWeakGlobalRef;
     ni.v24.ExceptionCheck = exception_check;

--- a/src/vm/jni/jni_env.rs
+++ b/src/vm/jni/jni_env.rs
@@ -56,7 +56,7 @@ use crate::vm::jni::string_operations_impl::{
 use crate::vm::jni::version_information_impl::get_version;
 use jni_sys::{
     jarray, jboolean, jbyte, jchar, jclass, jdouble, jfieldID, jfloat, jint, jlong, jmethodID,
-    jobject, jobjectRefType, jshort, jsize, jstring, jthrowable, jvalue, jweak, va_list, JNIEnv,
+    jobject, jobjectRefType, jshort, jsize, jthrowable, jvalue, jweak, va_list, JNIEnv,
     JNIInvokeInterface_, JNINativeInterface_, JNINativeMethod, JavaVM,
 };
 use std::ffi::{c_char, c_void};

--- a/src/vm/jni/jni_env.rs
+++ b/src/vm/jni/jni_env.rs
@@ -227,10 +227,8 @@ jni_stub!(RegisterNatives(jclass, *const JNINativeMethod, jint) -> jint);
 jni_stub!(UnregisterNatives(jclass) -> jint);
 jni_stub!(MonitorEnter(jobject) -> jint);
 jni_stub!(MonitorExit(jobject) -> jint);
-// GetStringRegion and GetStringUTFRegion are implemented in string_operations_impl.rs
 jni_stub!(GetPrimitiveArrayCritical(jarray, *mut jboolean) -> *mut c_void);
 jni_stub!(ReleasePrimitiveArrayCritical(jarray, *mut c_void, jint) -> ());
-// GetStringCritical and ReleaseStringCritical are implemented in string_operations_impl.rs
 jni_stub!(NewWeakGlobalRef(jobject) -> jweak);
 jni_stub!(DeleteWeakGlobalRef(jweak) -> ());
 jni_stub!(NewDirectByteBuffer(*mut c_void, jlong) -> jobject);

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -223,3 +223,126 @@ pub(super) extern "system" fn release_string_utf_chars(
         let _boxed: Box<_> = Box::from_raw(ptr::slice_from_raw_parts_mut(chars as *mut u8, len));
     }
 }
+
+/// GetStringRegion: Copies a region of the string into the provided buffer.
+/// Throws StringIndexOutOfBoundsException if the range is invalid.
+pub(super) extern "system" fn get_string_region(
+    _env: *mut JNIEnv,
+    str: jstring,
+    start: jsize,
+    len: jsize,
+    buf: *mut jchar,
+) {
+    if str.is_null() {
+        panic!("Invalid string reference: null"); // todo throw NullPointerException here
+    }
+    if buf.is_null() {
+        panic!("Null buffer passed to GetStringRegion"); // todo throw NullPointerException here
+    }
+
+    let string_ref = str as i32;
+    let string_len = {
+        let raw =
+            Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
+                .expect("Failed to get string length");
+        raw[0] as jsize
+    };
+
+    // Check bounds
+    if start < 0 || len < 0 || start > string_len || start + len > string_len {
+        panic!(
+            "StringIndexOutOfBoundsException: Range [{}, {}) out of bounds for length {}",
+            start,
+            start + len,
+            string_len
+        ); // todo throw StringIndexOutOfBoundsException here
+    }
+
+    // Get the raw UTF-16 data
+    let raw_data = get_string_raw_data(string_ref);
+
+    // Copy the region to the buffer
+    unsafe {
+        let src_slice = &raw_data[start as usize..(start + len) as usize];
+        let dst_slice = std::slice::from_raw_parts_mut(buf, len as usize);
+        dst_slice.copy_from_slice(src_slice);
+    }
+}
+
+/// GetStringUTFRegion: Copies a region of the string as modified UTF-8 into the provided buffer.
+/// The caller must ensure the buffer is large enough (use GetStringUTFLength for the full string,
+/// or calculate the region size manually).
+/// Throws StringIndexOutOfBoundsException if the range is invalid.
+pub(super) extern "system" fn get_string_utf_region(
+    _env: *mut JNIEnv,
+    str: jstring,
+    start: jsize,
+    len: jsize,
+    buf: *mut c_char,
+) {
+    if str.is_null() {
+        panic!("Invalid string reference: null"); // todo throw NullPointerException here
+    }
+    if buf.is_null() {
+        panic!("Null buffer passed to GetStringUTFRegion"); // todo throw NullPointerException here
+    }
+
+    let string_ref = str as i32;
+    let string_len = {
+        let raw =
+            Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
+                .expect("Failed to get string length");
+        raw[0] as jsize
+    };
+
+    // Check bounds
+    if start < 0 || len < 0 || start > string_len || start + len > string_len {
+        panic!(
+            "StringIndexOutOfBoundsException: Range [{}, {}) out of bounds for length {}",
+            start,
+            start + len,
+            string_len
+        ); // todo throw StringIndexOutOfBoundsException here
+    }
+
+    // Get the raw UTF-16 data and extract the region
+    let raw_data = get_string_raw_data(string_ref);
+    let region: Vec<jchar> = raw_data[start as usize..(start + len) as usize].to_vec();
+
+    // Convert to a Rust String from UTF-16
+    let rust_string =
+        String::from_utf16(&region).expect("Failed to build string from UTF-16 data");
+
+    // Convert to modified UTF-8 (CESU-8)
+    let mutf8_data = to_java_cesu8(&rust_string);
+
+    // Copy to the caller's buffer (including null terminator)
+    unsafe {
+        let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len() + 1);
+        dst_slice[..mutf8_data.len()].copy_from_slice(&mutf8_data);
+        dst_slice[mutf8_data.len()] = 0; // null terminator
+    }
+}
+
+/// GetStringCritical: Returns a pointer to the string's characters.
+/// This is similar to GetStringChars but signals that a GC-critical section has started.
+/// Since there's no GC yet in rusty-jvm, this is just a wrapper around GetStringChars.
+pub(super) extern "system" fn get_string_critical(
+    env: *mut JNIEnv,
+    str: jstring,
+    is_copy: *mut jboolean,
+) -> *const jchar {
+    // No GC yet, so this is equivalent to GetStringChars
+    get_string_chars(env, str, is_copy)
+}
+
+/// ReleaseStringCritical: Releases the pointer obtained from GetStringCritical.
+/// Since there's no GC yet in rusty-jvm, this is just a wrapper around ReleaseStringChars.
+pub(super) extern "system" fn release_string_critical(
+    env: *mut JNIEnv,
+    str: jstring,
+    carray: *const jchar,
+) {
+    // No GC yet, so this is equivalent to ReleaseStringChars
+    release_string_chars(env, str, carray);
+}

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -233,29 +233,23 @@ pub(super) extern "system" fn get_string_region(
     len: jsize,
     buf: *mut jchar,
 ) {
-    if str.is_null() {
-        panic!("Invalid string reference: null"); // todo throw NullPointerException here
-    }
-    if buf.is_null() {
-        panic!("Null buffer passed to GetStringRegion"); // todo throw NullPointerException here
+    if str.is_null() || buf.is_null() {
+        // todo: throw NullPointerException
+        return;
     }
 
     let string_ref = str as i32;
     let string_len = {
         let raw =
             Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
-                .expect("Failed to get string length");
+                .unwrap_or(vec![0]);
         raw[0] as jsize
     };
 
-    // Check bounds
-    if start < 0 || len < 0 || start > string_len || start + len > string_len {
-        panic!(
-            "StringIndexOutOfBoundsException: Range [{}, {}) out of bounds for length {}",
-            start,
-            start + len,
-            string_len
-        ); // todo throw StringIndexOutOfBoundsException here
+    // Check bounds (using overflow-safe comparison)
+    if start < 0 || len < 0 || start > string_len || len > string_len - start {
+        // todo: throw StringIndexOutOfBoundsException
+        return;
     }
 
     // Get the raw UTF-16 data
@@ -271,7 +265,8 @@ pub(super) extern "system" fn get_string_region(
 
 /// GetStringUTFRegion: Copies a region of the string as modified UTF-8 into the provided buffer.
 /// The caller must ensure the buffer is large enough (use GetStringUTFLength for the full string,
-/// or calculate the region size manually).
+/// or calculate the region size manually - worst case is 6 bytes per char for supplementary
+/// characters in CESU-8: two 3-byte surrogate sequences).
 /// Throws StringIndexOutOfBoundsException if the range is invalid.
 pub(super) extern "system" fn get_string_utf_region(
     _env: *mut JNIEnv,
@@ -280,29 +275,23 @@ pub(super) extern "system" fn get_string_utf_region(
     len: jsize,
     buf: *mut c_char,
 ) {
-    if str.is_null() {
-        panic!("Invalid string reference: null"); // todo throw NullPointerException here
-    }
-    if buf.is_null() {
-        panic!("Null buffer passed to GetStringUTFRegion"); // todo throw NullPointerException here
+    if str.is_null() || buf.is_null() {
+        // todo: throw NullPointerException
+        return;
     }
 
     let string_ref = str as i32;
     let string_len = {
         let raw =
             Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
-                .expect("Failed to get string length");
+                .unwrap_or(vec![0]);
         raw[0] as jsize
     };
 
-    // Check bounds
-    if start < 0 || len < 0 || start > string_len || start + len > string_len {
-        panic!(
-            "StringIndexOutOfBoundsException: Range [{}, {}) out of bounds for length {}",
-            start,
-            start + len,
-            string_len
-        ); // todo throw StringIndexOutOfBoundsException here
+    // Check bounds (using overflow-safe comparison)
+    if start < 0 || len < 0 || start > string_len || len > string_len - start {
+        // todo: throw StringIndexOutOfBoundsException
+        return;
     }
 
     // Get the raw UTF-16 data and extract the region
@@ -327,22 +316,33 @@ pub(super) extern "system" fn get_string_utf_region(
 /// GetStringCritical: Returns a pointer to the string's characters.
 /// This is similar to GetStringChars but signals that a GC-critical section has started.
 /// Since there's no GC yet in rusty-jvm, this is just a wrapper around GetStringChars.
+/// TODO(GC): When GC is implemented, this must:
+///   1. Pin the string object to prevent it from being moved during collection
+///   2. Disable GC for the duration of the critical section
+///   3. Return a direct pointer to the string's internal char array (no copy) when possible
 pub(super) extern "system" fn get_string_critical(
     env: *mut JNIEnv,
     str: jstring,
     is_copy: *mut jboolean,
 ) -> *const jchar {
     // No GC yet, so this is equivalent to GetStringChars
+    // TODO(GC): Pin object and disable GC here
     get_string_chars(env, str, is_copy)
 }
 
 /// ReleaseStringCritical: Releases the pointer obtained from GetStringCritical.
 /// Since there's no GC yet in rusty-jvm, this is just a wrapper around ReleaseStringChars.
+/// TODO(GC): When GC is implemented, this must:
+///   1. Unpin the string object
+///   2. Re-enable GC
+///   3. Must NOT be called between GetStringCritical and ReleaseStringCritical:
+///      - NewString, NewCharArray, SetCharArrayRegion (any allocating JNI function)
 pub(super) extern "system" fn release_string_critical(
     env: *mut JNIEnv,
     str: jstring,
     carray: *const jchar,
 ) {
     // No GC yet, so this is equivalent to ReleaseStringChars
+    // TODO(GC): Unpin object and re-enable GC here
     release_string_chars(env, str, carray);
 }

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -257,16 +257,13 @@ pub(super) extern "system" fn get_string_region(
 
     // Copy the region to the buffer
     unsafe {
-        let src_slice = &raw_data[start as usize..(start + len) as usize];
+        let src_slice = &raw_data[start as usize..start as usize + len as usize];
         let dst_slice = std::slice::from_raw_parts_mut(buf, len as usize);
         dst_slice.copy_from_slice(src_slice);
     }
 }
 
 /// GetStringUTFRegion: Copies a region of the string as modified UTF-8 into the provided buffer.
-/// The caller must ensure the buffer is large enough (use GetStringUTFLength for the full string,
-/// or calculate the region size manually - worst case is 6 bytes per char for supplementary
-/// characters in CESU-8: two 3-byte surrogate sequences).
 /// Throws StringIndexOutOfBoundsException if the range is invalid.
 pub(super) extern "system" fn get_string_utf_region(
     _env: *mut JNIEnv,
@@ -296,20 +293,21 @@ pub(super) extern "system" fn get_string_utf_region(
 
     // Get the raw UTF-16 data and extract the region
     let raw_data = get_string_raw_data(string_ref);
-    let region: Vec<jchar> = raw_data[start as usize..(start + len) as usize].to_vec();
+    let region: Vec<jchar> = raw_data[start as usize..start as usize + len as usize].to_vec();
 
     // Convert to a Rust String from UTF-16
-    let rust_string =
-        String::from_utf16(&region).expect("Failed to build string from UTF-16 data");
+    let rust_string = match String::from_utf16(&region) {
+        Ok(s) => s,
+        Err(_) => return, // todo: throw InternalError
+    };
 
     // Convert to modified UTF-8 (CESU-8)
     let mutf8_data = to_java_cesu8(&rust_string);
 
-    // Copy to the caller's buffer (including null terminator)
+    // Copy to the caller's buffer
     unsafe {
-        let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len() + 1);
-        dst_slice[..mutf8_data.len()].copy_from_slice(&mutf8_data);
-        dst_slice[mutf8_data.len()] = 0; // null terminator
+        let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len());
+        dst_slice.copy_from_slice(&mutf8_data);
     }
 }
 

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -11,6 +11,82 @@ use jni_sys::{jboolean, jbyte, jchar, jint, jlong, jsize, jstring, JNIEnv, JNI_T
 use std::ffi::c_char;
 use std::ptr;
 
+/// Encode a slice of UTF-16 code units directly to Java's modified UTF-8 (CESU-8/MUTF-8).
+/// This handles surrogate pairs and isolated surrogates correctly per JNI spec.
+fn encode_utf16_to_modified_utf8(utf16: &[u16]) -> Vec<u8> {
+    let mut result = Vec::new();
+    let mut i = 0;
+
+    while i < utf16.len() {
+        let c = utf16[i];
+
+        // Check for surrogate
+        if (0xD800..=0xDBFF).contains(&c) {
+            // High surrogate - try to pair with next code unit
+            if i + 1 < utf16.len() {
+                let next = utf16[i + 1];
+                if (0xDC00..=0xDFFF).contains(&next) {
+                    // Valid surrogate pair - encode combined supplementary char
+                    let high = (c as u32 - 0xD800) << 10;
+                    let low = (next as u32) - 0xDC00;
+                    let codepoint = high + low + 0x10000;
+                    encode_codepoint_to_mutf8(codepoint, &mut result);
+                    i += 2;
+                    continue;
+                }
+            }
+            // Isolated high surrogate - encode as individual code point
+            encode_codepoint_to_mutf8(c as u32, &mut result);
+        } else if (0xDC00..=0xDFFF).contains(&c) {
+            // Isolated low surrogate - encode as individual code point
+            encode_codepoint_to_mutf8(c as u32, &mut result);
+        } else {
+            // Regular BMP character
+            encode_codepoint_to_mutf8(c as u32, &mut result);
+        }
+        i += 1;
+    }
+
+    result
+}
+
+/// Encode a single Unicode code point to modified UTF-8 bytes.
+fn encode_codepoint_to_mutf8(codepoint: u32, buf: &mut Vec<u8>) {
+    if codepoint == 0x0000 {
+        // Modified UTF-8 encodes null as two bytes
+        buf.push(0xC0);
+        buf.push(0x80);
+    } else if codepoint <= 0x007F {
+        // ASCII
+        buf.push(codepoint as u8);
+    } else if codepoint <= 0x07FF {
+        // 2-byte sequence
+        buf.push(0xC0 | ((codepoint >> 6) as u8 & 0x1F));
+        buf.push(0x80 | (codepoint as u8 & 0x3F));
+    } else if codepoint <= 0xFFFF {
+        // 3-byte sequence (BMP, including isolated surrogates)
+        buf.push(0xE0 | ((codepoint >> 12) as u8 & 0x0F));
+        buf.push(0x80 | ((codepoint >> 6) as u8 & 0x3F));
+        buf.push(0x80 | (codepoint as u8 & 0x3F));
+    } else {
+        // Supplementary character - 6-byte CESU-8 sequence (not standard UTF-8!)
+        // This encodes the supplementary char as if it were two surrogates.
+        // The 0xA0/0xB0 bases encode the fixed upper bits of surrogate ranges.
+        let high = 0xD800u32 | ((codepoint - 0x10000) >> 10);
+        let low = 0xDC00u32 | ((codepoint - 0x10000) & 0x3FF);
+
+        // high ∈ [0xD800,0xDBFF]: byte2 must be 0xA0-0xAF
+        buf.push(0xED);
+        buf.push(0xA0 | ((high >> 6) as u8 & 0x0F)); // bits [9:6], base 0xA0
+        buf.push(0x80 | (high as u8 & 0x3F));
+
+        // low ∈ [0xDC00,0xDFFF]: byte2 must be 0xB0-0xBF
+        buf.push(0xED);
+        buf.push(0xB0 | ((low >> 6) as u8 & 0x0F)); // bits [9:6], base 0xB0
+        buf.push(0x80 | (low as u8 & 0x3F));
+    }
+}
+
 pub(super) extern "system" fn get_string_length(_env: *mut JNIEnv, input: jstring) -> jint {
     let string_ref = input as i32;
 
@@ -38,13 +114,15 @@ pub(super) extern "system" fn new_string(
     }
     let arr_ref = new_char_array(env, len);
     set_char_array_region(env, arr_ref, 0, len, unicode);
-    let string_instance_ref = Executor::invoke_args_constructor(
+    let string_instance_ref = match Executor::invoke_args_constructor(
         "java/lang/String",
         "<init>:([C)V",
         &[(arr_ref as i32).into()],
         Some(""),
-    )
-    .expect("Failed to invoke String constructor"); // todo handle exception here
+    ) {
+        Ok(result) => result,
+        Err(e) => panic!("Failed to invoke String constructor: {e}"), // todo handle exception here
+    };
 
     string_instance_ref as jstring
 }
@@ -73,17 +151,21 @@ pub(super) extern "system" fn get_string_chars(
 }
 
 fn get_string_raw_data(string_ref: i32) -> Vec<jchar> {
-    let (is_latin, array_ref) =
-        get_raw_string_info(string_ref).expect("Failed to get raw string info");
+    let (is_latin, array_ref) = match get_raw_string_info(string_ref) {
+        Ok(info) => info,
+        Err(e) => panic!("Failed to get raw string info: {e}"),
+    };
     let raw_data = if is_latin {
-        let guard = HEAP
-            .get_entire_raw_data(array_ref)
-            .expect("Failed to get string data");
+        let guard = match HEAP.get_entire_raw_data(array_ref) {
+            Ok(g) => g,
+            Err(e) => panic!("Failed to get string data: {e}"),
+        };
         guard.iter().map(|x| *x as jchar).collect::<Vec<_>>()
     } else {
-        let guard = HEAP
-            .get_entire_raw_data(array_ref)
-            .expect("Failed to get string data");
+        let guard = match HEAP.get_entire_raw_data(array_ref) {
+            Ok(g) => g,
+            Err(e) => panic!("Failed to get string data: {e}"),
+        };
         if guard.len() % 2 != 0 {
             panic!("Invalid UTF16 String data");
         }
@@ -130,7 +212,10 @@ pub(super) extern "system" fn new_string_utf8(
         panic!("modified utf-8 array is null");
     }
 
-    let decoded = from_mutf8_ptr!(mutf8_bytes).expect("Failed to decode modified UTF-8 bytes");
+    let decoded = match from_mutf8_ptr!(mutf8_bytes) {
+        Ok(d) => d,
+        Err(e) => panic!("Failed to decode modified UTF-8 bytes: {e}"),
+    };
     let decoded_bytes = decoded.as_bytes();
 
     let len = decoded_bytes.len() as jsize;
@@ -143,21 +228,30 @@ pub(super) extern "system" fn new_string_utf8(
         decoded_bytes.as_ptr() as *const jbyte,
     );
 
-    let utf8_charset_ref = CLASSES
-        .get("java/nio/charset/StandardCharsets")
-        .expect("Failed to get StandardCharsets class")
-        .static_field("UTF_8")
-        .expect("Failed to get UTF_8 field")
-        .raw_value()
-        .expect("Failed to get UTF_8 value")[0];
+    let utf8_charset_ref = {
+        let class = match CLASSES.get("java/nio/charset/StandardCharsets") {
+            Ok(c) => c,
+            Err(e) => panic!("Failed to get StandardCharsets class: {e}"),
+        };
+        let field = match class.static_field("UTF_8") {
+            Some(f) => f,
+            None => panic!("Failed to get UTF_8 field"),
+        };
+        match field.raw_value() {
+            Ok(v) => v[0],
+            Err(e) => panic!("Failed to get UTF_8 value: {e}"),
+        }
+    };
 
-    let string_instance_ref = Executor::invoke_args_constructor(
+    let string_instance_ref = match Executor::invoke_args_constructor(
         "java/lang/String",
         "<init>:([BLjava/nio/charset/Charset;)V",
         &[(byte_array as i32).into(), utf8_charset_ref.into()],
         Some(""),
-    )
-    .expect("Failed to invoke String constructor"); // todo handle exception here
+    ) {
+        Ok(result) => result,
+        Err(e) => panic!("Failed to invoke String constructor: {e}"), // todo handle exception here
+    };
 
     string_instance_ref as jstring
 }
@@ -173,7 +267,10 @@ pub(super) extern "system" fn get_string_utf_length_as_long(
     }
 
     let raw_data = get_string_raw_data(string_ref);
-    let data = String::from_utf16(&raw_data).expect("Failed to build string from UTF-16 data");
+    let data = match String::from_utf16(&raw_data) {
+        Ok(s) => s,
+        Err(e) => panic!("Failed to build string from UTF-16 data: {e}"),
+    };
     to_java_cesu8(&data).len() as jlong
 }
 
@@ -234,25 +331,19 @@ pub(super) extern "system" fn get_string_region(
     buf: *mut jchar,
 ) {
     if str.is_null() || buf.is_null() {
-        // todo: throw NullPointerException
-        return;
+        panic!("Null pointer in GetStringRegion"); // todo throw NullPointerException
     }
 
-    let string_ref = str as i32;
-    let string_len = {
-        let raw =
-            Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
-                .unwrap_or(vec![0]);
-        raw[0] as jsize
-    };
+    let string_len = get_string_length(_env, str) as jsize;
 
     // Check bounds (using overflow-safe comparison)
     if start < 0 || len < 0 || start > string_len || len > string_len - start {
-        // todo: throw StringIndexOutOfBoundsException
-        return;
+        panic!("Invalid string region: start={start}, len={len}, string_len={string_len}");
+        // todo throw StringIndexOutOfBoundsException
     }
 
     // Get the raw UTF-16 data
+    let string_ref = str as i32;
     let raw_data = get_string_raw_data(string_ref);
 
     // Copy the region to the buffer
@@ -273,38 +364,29 @@ pub(super) extern "system" fn get_string_utf_region(
     buf: *mut c_char,
 ) {
     if str.is_null() || buf.is_null() {
-        // todo: throw NullPointerException
-        return;
+        panic!("Null pointer in GetStringUTFRegion"); // todo throw NullPointerException
     }
 
-    let string_ref = str as i32;
-    let string_len = {
-        let raw =
-            Executor::invoke_non_static_method("java/lang/String", "length:()I", string_ref, &[])
-                .unwrap_or(vec![0]);
-        raw[0] as jsize
-    };
+    let string_len = get_string_length(_env, str) as jsize;
 
     // Check bounds (using overflow-safe comparison)
     if start < 0 || len < 0 || start > string_len || len > string_len - start {
-        // todo: throw StringIndexOutOfBoundsException
-        return;
+        panic!("Invalid string region: start={start}, len={len}, string_len={string_len}");
+        // todo throw StringIndexOutOfBoundsException
     }
 
     // Get the raw UTF-16 data and extract the region
+    let string_ref = str as i32;
     let raw_data = get_string_raw_data(string_ref);
-    let region: Vec<jchar> = raw_data[start as usize..start as usize + len as usize].to_vec();
+    let region = &raw_data[start as usize..start as usize + len as usize];
 
-    // Convert to a Rust String from UTF-16
-    let rust_string = match String::from_utf16(&region) {
-        Ok(s) => s,
-        Err(_) => return, // todo: throw InternalError
-    };
+    // Encode directly to modified UTF-8 without round-tripping through Rust String.
+    // This handles isolated surrogates and split surrogate pairs correctly per JNI spec.
+    let mutf8_data = encode_utf16_to_modified_utf8(region);
 
-    // Convert to modified UTF-8 (CESU-8)
-    let mutf8_data = to_java_cesu8(&rust_string);
-
-    // Copy to the caller's buffer with null terminator (JNI spec requires len bytes + \0)
+    // Copy to the caller's buffer: mutf8_data.len() bytes plus a null terminator.
+    // The caller should size buf via GetStringUTFLength on the same region, since
+    // the modified UTF-8 encoding may produce more bytes than the number of UTF-16 code units.
     unsafe {
         let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len() + 1);
         dst_slice[..mutf8_data.len()].copy_from_slice(&mutf8_data);

--- a/src/vm/jni/string_operations_impl.rs
+++ b/src/vm/jni/string_operations_impl.rs
@@ -304,10 +304,11 @@ pub(super) extern "system" fn get_string_utf_region(
     // Convert to modified UTF-8 (CESU-8)
     let mutf8_data = to_java_cesu8(&rust_string);
 
-    // Copy to the caller's buffer
+    // Copy to the caller's buffer with null terminator (JNI spec requires len bytes + \0)
     unsafe {
-        let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len());
-        dst_slice.copy_from_slice(&mutf8_data);
+        let dst_slice = std::slice::from_raw_parts_mut(buf as *mut u8, mutf8_data.len() + 1);
+        dst_slice[..mutf8_data.len()].copy_from_slice(&mutf8_data);
+        dst_slice[mutf8_data.len()] = 0; // null terminator
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3420,6 +3420,11 @@ Result of GetStringRegion('Hello, JNI 💅☕️!', 10, 6): [32, 55357, 56453, 9
 === GetStringUTFRegion ===
 Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 0, 5): 'Hello'
 Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 7, 3): 'JNI'
+Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 11, 2): '💅'
+Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 13, 1): '☕'
+Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 11, 4): '💅☕️'
+Raw bytes of GetStringUTFRegion('Hello, JNI 💅☕️!', 11, 1): [237, 160, 189]
+Raw bytes of GetStringUTFRegion('Hello, JNI 💅☕️!', 12, 1): [237, 178, 133]
 
 === GetStringCritical ===
 Result of GetStringCritical with input 'Hello, JNI 💅☕️!': [72, 101, 108, 108, 111, 44, 32, 74, 78, 73, 32, 55357, 56453, 9749, 65039, 33]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3415,14 +3415,14 @@ Result of GetStringUTFChars with input 'abc': 'abc'
 === GetStringRegion ===
 Result of GetStringRegion('Hello, JNI 💅☕️!', 0, 5): [72, 101, 108, 108, 111]
 Result of GetStringRegion('Hello, JNI 💅☕️!', 7, 3): [74, 78, 73]
-Result of GetStringRegion('Hello, JNI 💅☕️!', 10, 6): [55357, 56453, 65039, 9749, 65039, 33]
+Result of GetStringRegion('Hello, JNI 💅☕️!', 10, 6): [32, 55357, 56453, 9749, 65039, 33]
 
 === GetStringUTFRegion ===
 Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 0, 5): 'Hello'
 Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 7, 3): 'JNI'
 
 === GetStringCritical ===
-Result of GetStringCritical with input 'Hello, JNI 💅☕️!': [72, 101, 108, 108, 111, 44, 32, 74, 78, 73, 32, 55357, 56453, 65039, 9749, 65039, 33]
+Result of GetStringCritical with input 'Hello, JNI 💅☕️!': [72, 101, 108, 108, 111, 44, 32, 74, 78, 73, 32, 55357, 56453, 9749, 65039, 33]
 Result of GetStringCritical with input 'abc': [97, 98, 99]
 
 === GetStringCriticalAndRelease ===

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3412,6 +3412,22 @@ Length of 'éabc': utfLengthLong=5, utfLengthInt=5 charsLength=4
 Result of GetStringUTFChars with input 'A{null}𝄞': 'A{null}𝄞'
 Result of GetStringUTFChars with input 'abc': 'abc'
 
+=== GetStringRegion ===
+Result of GetStringRegion('Hello, JNI 💅☕️!', 0, 5): [72, 101, 108, 108, 111]
+Result of GetStringRegion('Hello, JNI 💅☕️!', 7, 3): [74, 78, 73]
+Result of GetStringRegion('Hello, JNI 💅☕️!', 10, 6): [55357, 56453, 65039, 9749, 65039, 33]
+
+=== GetStringUTFRegion ===
+Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 0, 5): 'Hello'
+Result of GetStringUTFRegion('Hello, JNI 💅☕️!', 7, 3): 'JNI'
+
+=== GetStringCritical ===
+Result of GetStringCritical with input 'Hello, JNI 💅☕️!': [72, 101, 108, 108, 111, 44, 32, 74, 78, 73, 32, 55357, 56453, 65039, 9749, 65039, 33]
+Result of GetStringCritical with input 'abc': [97, 98, 99]
+
+=== GetStringCriticalAndRelease ===
+Result of GetStringCriticalAndRelease with input 'A{null}𝄞💅☕️': 'A{null}𝄞💅☕️'
+
 === GetArrayLength ===
 Length of array [1, 2, 3, 4, 5] is 5
 Length of array [one, two, three] is 3

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -117,7 +117,9 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     start: jint,
     len: jint,
 ) -> jstring {
-    let mut buf: Vec<u8> = vec![0; (len * 3 + 1) as usize]; // max 3 bytes per char + null terminator
+    // Buffer sizing: worst case is 6 bytes per char for supplementary chars in CESU-8
+    // (two 3-byte surrogate sequences). Using len*3+1 is sufficient for BMP-only tests.
+    let mut buf: Vec<u8> = vec![0; (len * 3 + 1) as usize];
     unsafe {
         ((*(*env)).v24.GetStringUTFRegion)(
             env,
@@ -136,9 +138,12 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     _class: jclass,
     input: jstring,
 ) -> jcharArray {
+    // Get length and allocate array BEFORE entering critical section
     let length = unsafe { ((*(*env)).v24.GetStringLength)(env, input) } as jsize;
-    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
     let char_array = unsafe { ((*(*env)).v24.NewCharArray)(env, length) };
+
+    // Critical section: no allocating JNI calls allowed between Get/Release
+    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
     unsafe {
         ((*(*env)).v24.GetCharArrayRegion)(env, char_array, 0, length, chars);
         ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
@@ -153,15 +158,19 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     _class: jclass,
     input: jstring,
 ) -> jstring {
-    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
+    // Get length BEFORE entering critical section
     let length = unsafe { ((*(*env)).v24.GetStringLength)(env, input) } as jsize;
 
-    // Create a new string from the critical chars
-    let new_str = unsafe { ((*(*env)).v24.NewString)(env, chars, length) };
+    // Critical section: no allocating JNI calls allowed between Get/Release
+    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
 
+    // Copy chars to a local buffer since we can't call NewString while in critical section
+    let mut local_buf: Vec<jchar> = vec![0; length as usize];
     unsafe {
+        std::ptr::copy_nonoverlapping(chars, local_buf.as_mut_ptr(), length as usize);
         ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
     }
 
-    new_str
+    // Now safe to allocate: create a new string from the local buffer
+    unsafe { ((*(*env)).v24.NewString)(env, local_buf.as_ptr(), length) }
 }

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -145,8 +145,8 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     // Critical section: no allocating JNI calls allowed between Get/Release
     let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
     unsafe {
-        // Cast const to mutable - safe here since GetCharArrayRegion only reads from source
-        ((*(*env)).v24.GetCharArrayRegion)(env, char_array, 0, length, chars as *mut jchar);
+        // Copy from the string's chars into char_array
+        ((*(*env)).v24.SetCharArrayRegion)(env, char_array, 0, length, chars);
         ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
     }
 

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -89,3 +89,79 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
 
     string_ref
 }
+
+#[no_mangle]
+pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperationsDemo_GetStringRegion(
+    env: *mut JNIEnv,
+    _class: jclass,
+    input: jstring,
+    start: jint,
+    len: jint,
+) -> jcharArray {
+    let length = len as jsize;
+    let char_array = unsafe { ((*(*env)).v24.NewCharArray)(env, length) };
+    let mut buf: Vec<jchar> = vec![0; len as usize];
+    unsafe {
+        ((*(*env)).v24.GetStringRegion)(env, input, start as jsize, length, buf.as_mut_ptr());
+        ((*(*env)).v24.SetCharArrayRegion)(env, char_array, 0, length, buf.as_ptr());
+    }
+
+    char_array
+}
+
+#[no_mangle]
+pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperationsDemo_GetStringUTFRegion(
+    env: *mut JNIEnv,
+    _class: jclass,
+    input: jstring,
+    start: jint,
+    len: jint,
+) -> jstring {
+    let mut buf: Vec<u8> = vec![0; (len * 3 + 1) as usize]; // max 3 bytes per char + null terminator
+    unsafe {
+        ((*(*env)).v24.GetStringUTFRegion)(
+            env,
+            input,
+            start as jsize,
+            len as jsize,
+            buf.as_mut_ptr() as *mut i8,
+        );
+        ((*(*env)).v24.NewStringUTF)(env, buf.as_ptr() as *const i8)
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperationsDemo_GetStringCritical(
+    env: *mut JNIEnv,
+    _class: jclass,
+    input: jstring,
+) -> jcharArray {
+    let length = unsafe { ((*(*env)).v24.GetStringLength)(env, input) } as jsize;
+    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
+    let char_array = unsafe { ((*(*env)).v24.NewCharArray)(env, length) };
+    unsafe {
+        ((*(*env)).v24.GetCharArrayRegion)(env, char_array, 0, length, chars);
+        ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
+    }
+
+    char_array
+}
+
+#[no_mangle]
+pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperationsDemo_GetStringCriticalAndRelease(
+    env: *mut JNIEnv,
+    _class: jclass,
+    input: jstring,
+) -> jstring {
+    let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
+    let length = unsafe { ((*(*env)).v24.GetStringLength)(env, input) } as jsize;
+
+    // Create a new string from the critical chars
+    let new_str = unsafe { ((*(*env)).v24.NewString)(env, chars, length) };
+
+    unsafe {
+        ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
+    }
+
+    new_str
+}

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -1,6 +1,7 @@
 use cesu8::to_java_cesu8;
 use jni::sys::{
-    jchar, jcharArray, jclass, jint, jlong, jobject, jsize, jstring, JNIEnv, JNI_ABORT,
+    jbyte, jbyteArray, jchar, jcharArray, jclass, jint, jlong, jobject, jsize, jstring, JNIEnv,
+    JNI_ABORT,
 };
 use std::ffi::CString;
 use std::ptr::null_mut;
@@ -137,6 +138,47 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
             buf.as_mut_ptr() as *mut i8,
         );
         ((*(*env)).v24.NewStringUTF)(env, buf.as_ptr() as *const i8)
+    }
+}
+
+/// Like `GetStringUTFRegion`, but returns the raw modified-UTF-8 bytes (without the trailing NUL)
+/// as a `byte[]`, bypassing the round-trip through `NewStringUTF`. This lets Java assertions
+/// observe the exact MUTF-8 encoding for regions that contain unpaired/split surrogates,
+/// which cannot be represented in a Rust `String` and therefore cannot survive a
+/// `NewStringUTF` round-trip.
+#[no_mangle]
+pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperationsDemo_GetStringUTFRegionRaw(
+    env: *mut JNIEnv,
+    _class: jclass,
+    input: jstring,
+    start: jint,
+    len: jint,
+) -> jbyteArray {
+    // Validate inputs to prevent wrap-around to huge usize values
+    if start < 0 || len < 0 {
+        return null_mut();
+    }
+    // See sibling `GetStringUTFRegion` for the buffer sizing rationale.
+    let mut buf: Vec<u8> = vec![0; (len * 3 + 1) as usize];
+    unsafe {
+        ((*(*env)).v24.GetStringUTFRegion)(
+            env,
+            input,
+            start as jsize,
+            len as jsize,
+            buf.as_mut_ptr() as *mut i8,
+        );
+        // Drop the trailing NUL terminator and find the actual encoded length.
+        let encoded_len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len()) as jsize;
+        let byte_array = ((*(*env)).v24.NewByteArray)(env, encoded_len);
+        ((*(*env)).v24.SetByteArrayRegion)(
+            env,
+            byte_array,
+            0,
+            encoded_len,
+            buf.as_ptr() as *const jbyte,
+        );
+        byte_array
     }
 }
 

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -142,12 +142,20 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     let length = unsafe { ((*(*env)).v24.GetStringLength)(env, input) } as jsize;
     let char_array = unsafe { ((*(*env)).v24.NewCharArray)(env, length) };
 
-    // Critical section: no allocating JNI calls allowed between Get/Release
+    // --- Enter critical section ---
     let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
+
+    // Copy to local buffer using only raw pointer ops (no JNI calls allowed here)
+    let mut local_buf: Vec<jchar> = vec![0; length as usize];
     unsafe {
-        // Copy from the string's chars into char_array
-        ((*(*env)).v24.SetCharArrayRegion)(env, char_array, 0, length, chars);
+        std::ptr::copy_nonoverlapping(chars, local_buf.as_mut_ptr(), length as usize);
         ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
+    }
+    // --- Exit critical section ---
+
+    // Now safe to call JNI functions
+    unsafe {
+        ((*(*env)).v24.SetCharArrayRegion)(env, char_array, 0, length, local_buf.as_ptr());
     }
 
     char_array

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -98,6 +98,10 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     start: jint,
     len: jint,
 ) -> jcharArray {
+    // Validate inputs to prevent wrap-around to huge usize values
+    if start < 0 || len < 0 {
+        return null_mut();
+    }
     let length = len as jsize;
     let char_array = unsafe { ((*(*env)).v24.NewCharArray)(env, length) };
     let mut buf: Vec<jchar> = vec![0; len as usize];
@@ -117,6 +121,10 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     start: jint,
     len: jint,
 ) -> jstring {
+    // Validate inputs to prevent wrap-around to huge usize values
+    if start < 0 || len < 0 {
+        return null_mut();
+    }
     // Buffer sizing: worst case is 6 bytes per char for supplementary chars in CESU-8
     // (two 3-byte surrogate sequences). Using len*3+1 is sufficient for BMP-only tests.
     let mut buf: Vec<u8> = vec![0; (len * 3 + 1) as usize];

--- a/tests/jni_test_lib/src/string_operations_demo.rs
+++ b/tests/jni_test_lib/src/string_operations_demo.rs
@@ -145,7 +145,8 @@ pub extern "system" fn Java_samples_javacore_loadlibrary_example_StringOperation
     // Critical section: no allocating JNI calls allowed between Get/Release
     let chars = unsafe { ((*(*env)).v24.GetStringCritical)(env, input, null_mut()) };
     unsafe {
-        ((*(*env)).v24.GetCharArrayRegion)(env, char_array, 0, length, chars);
+        // Cast const to mutable - safe here since GetCharArrayRegion only reads from source
+        ((*(*env)).v24.GetCharArrayRegion)(env, char_array, 0, length, chars as *mut jchar);
         ((*(*env)).v24.ReleaseStringCritical)(env, input, chars);
     }
 

--- a/tests/test_data/LoadLibraryExample.java
+++ b/tests/test_data/LoadLibraryExample.java
@@ -104,6 +104,10 @@ class StringOperationsDemo {
     private static native int GetStringUTFLength(String input);
     private static native long GetStringUTFLengthAsLong(String input);
     private static native String GetStringUTFChars(String input);
+    private static native char[] GetStringRegion(String input, int start, int len);
+    private static native String GetStringUTFRegion(String input, int start, int len);
+    private static native char[] GetStringCritical(String input);
+    private static native String GetStringCriticalAndRelease(String input);
 
     public static void runDemo() {
         GetStringLengthDemo();
@@ -112,6 +116,10 @@ class StringOperationsDemo {
         NewStringUTFDemo();
         GetStringUTFLengthAsLongDemo();
         GetStringUTFCharsDemo();
+        GetStringRegionDemo();
+        GetStringUTFRegionDemo();
+        GetStringCriticalDemo();
+        GetStringCriticalAndReleaseDemo();
     }
 
     private static void GetStringLengthDemo() {
@@ -188,6 +196,55 @@ class StringOperationsDemo {
         String latinInput = "abc";
         String latinOutput = GetStringUTFChars(latinInput);
         System.out.printf("Result of GetStringUTFChars with input '%s': '%s'%n", latinInput, latinOutput);
+    }
+
+    private static void GetStringRegionDemo() {
+        System.out.println();
+        System.out.println("=== GetStringRegion ===");
+
+        String testString = "Hello, JNI 💅☕️!";
+        char[] region1 = GetStringRegion(testString, 0, 5);
+        System.out.printf("Result of GetStringRegion('%s', 0, 5): %s%n", testString, Arrays.toString(toUtf16CodeUnits(region1)));
+
+        char[] region2 = GetStringRegion(testString, 7, 3);
+        System.out.printf("Result of GetStringRegion('%s', 7, 3): %s%n", testString, Arrays.toString(toUtf16CodeUnits(region2)));
+
+        char[] region3 = GetStringRegion(testString, 10, 6);
+        System.out.printf("Result of GetStringRegion('%s', 10, 6): %s%n", testString, Arrays.toString(toUtf16CodeUnits(region3)));
+    }
+
+    private static void GetStringUTFRegionDemo() {
+        System.out.println();
+        System.out.println("=== GetStringUTFRegion ===");
+
+        String testString = "Hello, JNI 💅☕️!";
+        String region1 = GetStringUTFRegion(testString, 0, 5);
+        System.out.printf("Result of GetStringUTFRegion('%s', 0, 5): '%s'%n", testString, region1);
+
+        String region2 = GetStringUTFRegion(testString, 7, 3);
+        System.out.printf("Result of GetStringUTFRegion('%s', 7, 3): '%s'%n", testString, region2);
+    }
+
+    private static void GetStringCriticalDemo() {
+        System.out.println();
+        System.out.println("=== GetStringCritical ===");
+
+        String utf16Input = "Hello, JNI 💅☕️!";
+        char[] utf16Chars = GetStringCritical(utf16Input);
+        System.out.printf("Result of GetStringCritical with input '%s': %s%n", utf16Input, Arrays.toString(toUtf16CodeUnits(utf16Chars)));
+
+        String latinInput = "abc";
+        char[] latinChars = GetStringCritical(latinInput);
+        System.out.printf("Result of GetStringCritical with input '%s': %s%n", latinInput, Arrays.toString(toUtf16CodeUnits(latinChars)));
+    }
+
+    private static void GetStringCriticalAndReleaseDemo() {
+        System.out.println();
+        System.out.println("=== GetStringCriticalAndRelease ===");
+
+        String utf16Input = "A\u0000𝄞💅☕️";
+        String result = GetStringCriticalAndRelease(utf16Input);
+        System.out.printf("Result of GetStringCriticalAndRelease with input '%s': '%s'%n", utf16Input, result);
     }
 }
 

--- a/tests/test_data/LoadLibraryExample.java
+++ b/tests/test_data/LoadLibraryExample.java
@@ -106,6 +106,7 @@ class StringOperationsDemo {
     private static native String GetStringUTFChars(String input);
     private static native char[] GetStringRegion(String input, int start, int len);
     private static native String GetStringUTFRegion(String input, int start, int len);
+    private static native byte[] GetStringUTFRegionRaw(String input, int start, int len);
     private static native char[] GetStringCritical(String input);
     private static native String GetStringCriticalAndRelease(String input);
 
@@ -223,6 +224,37 @@ class StringOperationsDemo {
 
         String region2 = GetStringUTFRegion(testString, 7, 3);
         System.out.printf("Result of GetStringUTFRegion('%s', 7, 3): '%s'%n", testString, region2);
+
+        // Full surrogate pair: exercises the 6-byte CESU-8 (supplementary char) encoding path.
+        String region3 = GetStringUTFRegion(testString, 11, 2);
+        System.out.printf("Result of GetStringUTFRegion('%s', 11, 2): '%s'%n", testString, region3);
+
+        // Non-ASCII BMP code point: exercises the 3-byte CESU-8 path.
+        String region4 = GetStringUTFRegion(testString, 13, 1);
+        System.out.printf("Result of GetStringUTFRegion('%s', 13, 1): '%s'%n", testString, region4);
+
+        // Mixed region: supplementary + BMP, covering both encoding paths in a single call.
+        String region5 = GetStringUTFRegion(testString, 11, 4);
+        System.out.printf("Result of GetStringUTFRegion('%s', 11, 4): '%s'%n", testString, region5);
+
+        // Split surrogate pair: the region cuts the 💅 (U+1F485) supplementary char in half,
+        // leaving the high surrogate U+D83D alone. Per the JNI spec, GetStringUTFRegion must
+        // emit the unpaired surrogate as a 3-byte CESU-8 sequence (0xED 0xA0 0xBD).
+        // This exercises the "isolated high surrogate" branch of encode_utf16_to_modified_utf8;
+        // the output cannot survive a NewStringUTF round-trip because Rust strings can't hold
+        // unpaired surrogates, so we read the raw bytes via GetStringUTFRegionRaw.
+        byte[] highHalf = GetStringUTFRegionRaw(testString, 11, 1);
+        System.out.printf("Raw bytes of GetStringUTFRegion('%s', 11, 1): %s%n", testString, Arrays.toString(toUnsignedInts(highHalf)));
+
+        // The matching low surrogate U+DC85 of 💅 must be emitted as 0xED 0xB0 0x85.
+        byte[] lowHalf = GetStringUTFRegionRaw(testString, 12, 1);
+        System.out.printf("Raw bytes of GetStringUTFRegion('%s', 12, 1): %s%n", testString, Arrays.toString(toUnsignedInts(lowHalf)));
+    }
+
+    private static int[] toUnsignedInts(byte[] bytes) {
+        return java.util.stream.IntStream.range(0, bytes.length)
+            .map(i -> bytes[i] & 0xFF)
+            .toArray();
     }
 
     private static void GetStringCriticalDemo() {


### PR DESCRIPTION
Closes #728

Implemented the remaining JNI string operations.
 Added support for GetStringRegion and GetStringUTFRegion, allowing callers to copy specific portions of a string into their own buffers.
 Implemented GetStringCritical and ReleaseStringCritical as thin wrappers over the existing accessors for now, with TODO(GC) notes in place for when proper pinning / GC interaction is introduced.

followed the existing // todo: throw XException  stub pattern to stay consistent with the current state of JNI exception handling, so it should slot cleanly into future work when proper exception support is added
