### PR TITLE
Fix parallelStream/ForkJoinPool deadlock by adding missing CAS natives

### DIFF
--- a/src/vm/system_native/dispatcher/builtin_natives.rs
+++ b/src/vm/system_native/dispatcher/builtin_natives.rs
@@ -499,6 +499,8 @@ builtin_natives! {
     "jdk/internal/misc/Unsafe": instance fn compareAndSetReference(obj: object, offset: long, expected: object, x: object) -> boolean => sn::unsafe_::compare_and_set_reference;
     "jdk/internal/misc/Unsafe": instance fn compareAndSetLong(obj: object, offset: long, expected: long, x: long) -> boolean => sn::unsafe_::compare_and_set_long;
     "jdk/internal/misc/Unsafe": instance fn compareAndExchangeLong(obj: object, offset: long, expected: long, x: long) -> long => sn::unsafe_::compare_and_exchange_long;
+    "jdk/internal/misc/Unsafe": instance fn compareAndExchangeInt(obj: object, offset: long, expected: int, x: int) -> int => sn::unsafe_::compare_and_exchange_int;
+    "jdk/internal/misc/Unsafe": instance fn compareAndExchangeReference(obj: object, offset: long, expected: object, x: object) -> object => sn::unsafe_::compare_and_exchange_reference;
     "jdk/internal/misc/Unsafe": instance fn getReferenceVolatile(obj: object, offset: long) -> object => sn::unsafe_::get_reference_volatile;
     "jdk/internal/misc/Unsafe": instance fn getByte(obj: object, offset: long) -> byte => sn::unsafe_::get_byte;
     "jdk/internal/misc/Unsafe": instance fn getShort(obj: object, offset: long) -> short => sn::unsafe_::get_short;

--- a/src/vm/system_native/dispatcher/polymorphic.rs
+++ b/src/vm/system_native/dispatcher/polymorphic.rs
@@ -1,7 +1,8 @@
 use crate::vm::error::{Error, Result};
 use crate::vm::system_native::method_handle_natives::wrappers::{
     method_handle_invoke_basic_wrp, method_handle_invoke_exact_wrp, method_handle_invoke_wrp,
-    var_handle_compare_and_set_wrp, var_handle_get_wrp, var_handle_set_wrp,
+    var_handle_compare_and_exchange_wrp, var_handle_compare_and_set_wrp, var_handle_get_wrp,
+    var_handle_set_wrp,
 };
 
 pub(crate) fn invoke_polymorphic(
@@ -16,6 +17,22 @@ pub(crate) fn invoke_polymorphic(
         ("java/lang/invoke/VarHandle", "set") => var_handle_set_wrp(args),
         ("java/lang/invoke/VarHandle", "get") => var_handle_get_wrp(args),
         ("java/lang/invoke/VarHandle", "compareAndSet") => var_handle_compare_and_set_wrp(args),
+        // A strong (volatile) CAS validly implements every `weakCompareAndSet*`: they are all
+        // permitted to fail spuriously and only differ in memory ordering (plain / acquire / release),
+        // which a stronger ordering satisfies. Callers loop and retry regardless
+        // (e.g. `AtomicReference.updateAndGet`). Route all four spellings to the same strong CAS.
+        (
+            "java/lang/invoke/VarHandle",
+            "weakCompareAndSet"
+            | "weakCompareAndSetPlain"
+            | "weakCompareAndSetAcquire"
+            | "weakCompareAndSetRelease",
+        ) => var_handle_compare_and_set_wrp(args),
+        // Likewise the acquire/release-ordered exchanges reduce to the volatile `compareAndExchange`.
+        (
+            "java/lang/invoke/VarHandle",
+            "compareAndExchange" | "compareAndExchangeAcquire" | "compareAndExchangeRelease",
+        ) => var_handle_compare_and_exchange_wrp(args),
         _ => Err(Error::new_native(&format!(
             "Unknown polymorphic-signature native method: {class_name}:{method_name}"
         ))),

--- a/src/vm/system_native/method_handle_natives/var_handle.rs
+++ b/src/vm/system_native/method_handle_natives/var_handle.rs
@@ -119,9 +119,68 @@ pub(crate) fn var_handle_compare_and_set(
             &all_args,
         )?;
         Ok(ret)
+    } else if name == "java/lang/invoke/VarHandleInts$FieldInstanceReadWrite" {
+        // e.g. `ForkJoinTask.status`, updated via `STATUS.compareAndSet(this, s, s | flags)`.
+        let ret = Executor::invoke_static_method(
+            &name,
+            "compareAndSet:(Ljava/lang/invoke/VarHandle;Ljava/lang/Object;II)Z",
+            &all_args,
+        )?;
+        Ok(ret)
+    } else if name == "java/lang/invoke/VarHandleBooleans$FieldInstanceReadWrite" {
+        // NOTE: boolean CAS is only reliable when the field sits alone in its word. The JDK routes
+        // `compareAndSetBoolean` through `compareAndSetByte`, which word-aligns the offset
+        // (`offset & ~3`) and masks in a byte. Because this VM's field offsets are dense slot indices
+        // (0,1,2,...) rather than byte addresses, a boolean whose index is not a multiple of 4 aliases
+        // a neighbouring field. `ForkJoinPool` relies on this path and its boolean field happens to be
+        // safe; general boolean-field CAS is not. See [[unsafe-subword-cas-offset-limitation]].
+        let ret = Executor::invoke_static_method(
+            &name,
+            "compareAndSet:(Ljava/lang/invoke/VarHandle;Ljava/lang/Object;ZZ)Z",
+            &all_args,
+        )?;
+        Ok(ret)
     } else {
         Err(crate::vm::error::Error::new_execution(&format!(
             "var_handle_compare_and_set - Unsupported VarHandle type: {name}"
+        )))
+    }
+}
+
+/// Backs the signature-polymorphic `VarHandle.compareAndExchange`. Like
+/// [`var_handle_compare_and_set`] but the guard method returns the *witness* value (the value found
+/// in the field, equal to `expected` on success) instead of a boolean. Used by e.g.
+/// `AtomicReference.compareAndExchange` / `updateAndGet`.
+pub(crate) fn var_handle_compare_and_exchange(
+    handle_ref: i32,
+    args_to_process: &[i32],
+) -> Result<Vec<i32>> {
+    let name = HEAP.get_instance_name(handle_ref)?;
+
+    let mut all_args = vec![handle_ref];
+    all_args.extend_from_slice(args_to_process);
+    let all_args = all_args
+        .into_iter()
+        .map(|a| a.into())
+        .collect::<Vec<StackValueKind>>();
+    if name == "java/lang/invoke/VarHandleReferences$FieldInstanceReadWrite" {
+        Executor::invoke_static_method(
+            &name,
+            "compareAndExchange:(Ljava/lang/invoke/VarHandle;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+            &all_args,
+        )
+    } else if name == "java/lang/invoke/VarHandleInts$FieldInstanceReadWrite" {
+        Executor::invoke_static_method(
+            &name,
+            "compareAndExchange:(Ljava/lang/invoke/VarHandle;Ljava/lang/Object;II)I",
+            &all_args,
+        )
+    } else {
+        // Booleans are intentionally omitted: boolean-field CAS corrupts neighbouring fields under
+        // this VM's slot-index offset model (see the note on the compareAndSet boolean branch and
+        // [[unsafe-subword-cas-offset-limitation]]). Failing fast is better than silent corruption.
+        Err(crate::vm::error::Error::new_execution(&format!(
+            "var_handle_compare_and_exchange - Unsupported VarHandle type: {name}"
         )))
     }
 }

--- a/src/vm/system_native/method_handle_natives/wrappers.rs
+++ b/src/vm/system_native/method_handle_natives/wrappers.rs
@@ -1,7 +1,7 @@
 use crate::vm::error::Result;
 use crate::vm::system_native::method_handle_natives::invocation::invoke_exact;
 use crate::vm::system_native::method_handle_natives::var_handle::{
-    var_handle_compare_and_set, var_handle_get, var_handle_set,
+    var_handle_compare_and_exchange, var_handle_compare_and_set, var_handle_get, var_handle_set,
 };
 
 pub(crate) fn method_handle_invoke_exact_wrp(args: &[i32]) -> Result<Vec<i32>> {
@@ -40,4 +40,11 @@ pub(crate) fn var_handle_compare_and_set_wrp(args: &[i32]) -> Result<Vec<i32>> {
     let args_to_process = &args[1..];
 
     var_handle_compare_and_set(handle_ref, args_to_process)
+}
+
+pub(crate) fn var_handle_compare_and_exchange_wrp(args: &[i32]) -> Result<Vec<i32>> {
+    let handle_ref = args[0];
+    let args_to_process = &args[1..];
+
+    var_handle_compare_and_exchange(handle_ref, args_to_process)
 }

--- a/src/vm/system_native/unsafe_.rs
+++ b/src/vm/system_native/unsafe_.rs
@@ -109,14 +109,42 @@ pub(crate) fn static_field_base0(_this: i32, field_ref: i32) -> Result<i32> {
 
 /// `jdk.internal.misc.Unsafe.compareAndSetInt(Ljava/lang/Object;JII)Z`
 pub(crate) fn compare_and_set_int(
-    _this: i32,
+    this: i32,
     obj_ref: i32,
     offset: i64,
     expected: i32,
     x: i32,
 ) -> Result<bool> {
+    let (swapped, _witness) = compare_and_x_int(this, obj_ref, offset, expected, x)?;
+    Ok(swapped)
+}
+
+/// `jdk.internal.misc.Unsafe.compareAndExchangeInt(Ljava/lang/Object;JII)I`
+///
+/// Like `compareAndSetInt` but returns the *witness* value (the value found in the field), which
+/// equals `expected` on success. `ForkJoinPool` uses this to advance task/queue status words.
+pub(crate) fn compare_and_exchange_int(
+    this: i32,
+    obj_ref: i32,
+    offset: i64,
+    expected: i32,
+    x: i32,
+) -> Result<i32> {
+    let (_swapped, witness) = compare_and_x_int(this, obj_ref, offset, expected, x)?;
+    Ok(witness)
+}
+
+/// Shared compare-and-swap for 32-bit slots (`int` and object references alike). Returns
+/// `(swapped, witness)` where `witness` is the value the field held before the attempt.
+fn compare_and_x_int(
+    _this: i32,
+    obj_ref: i32,
+    offset: i64,
+    expected: i32,
+    x: i32,
+) -> Result<(bool, i32)> {
     let class_name = HEAP.get_instance_name(obj_ref)?;
-    let (_old, swapped) = if class_name.starts_with("[") {
+    let (old, swapped) = if class_name.starts_with("[") {
         HEAP.compare_and_exchange_array_by_raw_offset(
             obj_ref,
             offset as usize,
@@ -143,7 +171,15 @@ pub(crate) fn compare_and_set_int(
         )?
     };
 
-    Ok(swapped)
+    // The witness is the field's prior value; `compareAndExchange*` returns it and witness-loops
+    // (e.g. `updateAndGet`, ForkJoin) depend on it being accurate. An empty `old` means the heap
+    // returned an unexpected shape, so error out rather than fabricate a `0` witness.
+    let witness = *old.first().ok_or_else(|| {
+        Error::new_execution(&format!(
+            "compare-and-exchange returned no prior value for offset {offset} on {class_name}"
+        ))
+    })?;
+    Ok((swapped, witness))
 }
 
 /// `jdk.internal.misc.Unsafe.compareAndSetReference(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z`
@@ -155,6 +191,20 @@ pub(crate) fn compare_and_set_reference(
     x: i32,
 ) -> Result<bool> {
     compare_and_set_int(this, obj_ref, offset, expected, x)
+}
+
+/// `jdk.internal.misc.Unsafe.compareAndExchangeReference(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;`
+///
+/// Reference-typed sibling of [`compare_and_exchange_int`]; returns the witness reference. Used by
+/// `ForkJoinPool`'s work-queue slot updates.
+pub(crate) fn compare_and_exchange_reference(
+    this: i32,
+    obj_ref: i32,
+    offset: i64,
+    expected: i32,
+    x: i32,
+) -> Result<i32> {
+    compare_and_exchange_int(this, obj_ref, offset, expected, x)
 }
 
 /// `jdk.internal.misc.Unsafe.getReference(Ljava/lang/Object;J)Ljava/lang/Object;`

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2900,6 +2900,82 @@ Product (parallel): 362880
 }
 
 #[test]
+fn should_support_fork_join_framework() {
+    // Exercises the ForkJoin framework (RecursiveTask/RecursiveAction/custom & common pools,
+    // fork/join, invokeAll) and parallel streams, including nested parallelism and a stress loop
+    // that keeps many pool workers parking and being woken. A regression in pool worker wake-up
+    // (or the Unsafe/VarHandle CAS primitives the pool coordinates through) deadlocks the pool, so
+    // this test would hang instead of producing the deterministic output below.
+    assert_success(
+        "samples.concurrency.forkjoin.ForkJoinExamples",
+        r#"RecursiveTask sum 1..10000 = 50005000
+RecursiveAction doubled sum = 16000
+Custom pool sum = 5000, parallelism = 3
+invokeAll sum = 12000
+parallel LongStream sum = 5000050000
+parallel product 1..12 = 479001600
+parallel evens: count = 10000, first = 0, last = 19998
+parallel partition %3: divisible = 3334, rest = 6666
+nested parallel total = 25025000
+stress loop 40 iterations consistent = true
+DONE
+"#,
+    );
+}
+
+#[test]
+fn should_support_atomic_compare_and_exchange() {
+    // Focused guard for the `compareAndExchange`/`compareAndSet` primitives that ForkJoin coordinates
+    // through: AtomicInteger/AtomicLong route to `Unsafe.compareAndExchangeInt/Long`, AtomicReference
+    // to the reference CAS. `compareAndExchange` returns the witness (prior) value.
+    assert_success(
+        "samples.concurrency.atomics.AtomicCasExamples",
+        r#"int witness on success = 10
+int witness on failure = 20
+int value = 20
+int compareAndSet fail = false
+int compareAndSet ok = true
+int getAndAdd = 40 -> 42
+long witness on success = 5000000000
+long compareAndSet ok = true
+long value = 7000000000
+ref witness on success = a
+ref witness on failure = b
+ref compareAndSet ok = true
+ref value = c
+ref updateAndGet = c!
+"#,
+    );
+}
+
+#[test]
+fn should_support_var_handle_compare_and_exchange() {
+    // Directly drives VarHandle compareAndSet / compareAndExchange / weakCompareAndSet on int and
+    // reference instance fields (the field-instance CAS branches, incl. the witness-returning
+    // compareAndExchange). Boolean fields are excluded on purpose: this VM's slot-index field
+    // offsets are incompatible with the JDK's word-masked compareAndSetByte path.
+    assert_success(
+        "samples.concurrency.varhandle.VarHandleCasExamples",
+        r#"int compareAndSet ok = true
+int compareAndExchange witness = 20
+int compareAndExchange fail witness = 30
+int compareAndExchangeAcquire witness = 30
+int compareAndExchangeRelease witness = 40
+int weakCompareAndSet = true
+int weakCompareAndSetPlain = true
+int weakCompareAndSetAcquire = true
+int weakCompareAndSetRelease = true
+int value = 90
+ref compareAndSet ok = true
+ref compareAndExchange witness = b
+ref compareAndExchange fail witness = c
+ref weakCompareAndSet = true
+ref value = d
+"#,
+    );
+}
+
+#[test]
 fn should_rethrow_an_exception() {
     assert_success(
         "samples.javacore.rethrowloopexample.RethrowExample",

--- a/tests/test_data/AtomicCasExamples.java
+++ b/tests/test_data/AtomicCasExamples.java
@@ -1,0 +1,36 @@
+package samples.concurrency.atomics;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Directly exercises the {@code compareAndSet} / {@code compareAndExchange} atomics that back the
+ * ForkJoin pool's coordination words. {@code AtomicInteger}/{@code AtomicLong}/{@code AtomicReference}
+ * route these through {@code Unsafe.compareAndExchangeInt/Long/Reference} (and, on some paths, the
+ * corresponding {@code VarHandle} CAS), so this is a focused regression guard for those primitives.
+ */
+public class AtomicCasExamples {
+    public static void main(String[] args) {
+        AtomicInteger i = new AtomicInteger(10);
+        // compareAndExchange returns the witness (prior) value.
+        System.out.println("int witness on success = " + i.compareAndExchange(10, 20));
+        System.out.println("int witness on failure = " + i.compareAndExchange(999, 30));
+        System.out.println("int value = " + i.get());
+        System.out.println("int compareAndSet fail = " + i.compareAndSet(999, 40));
+        System.out.println("int compareAndSet ok = " + i.compareAndSet(20, 40));
+        System.out.println("int getAndAdd = " + i.getAndAdd(2) + " -> " + i.get());
+
+        AtomicLong l = new AtomicLong(5_000_000_000L);
+        System.out.println("long witness on success = " + l.compareAndExchange(5_000_000_000L, 6_000_000_000L));
+        System.out.println("long compareAndSet ok = " + l.compareAndSet(6_000_000_000L, 7_000_000_000L));
+        System.out.println("long value = " + l.get());
+
+        AtomicReference<String> r = new AtomicReference<>("a");
+        System.out.println("ref witness on success = " + r.compareAndExchange("a", "b"));
+        System.out.println("ref witness on failure = " + r.compareAndExchange("zzz", "c"));
+        System.out.println("ref compareAndSet ok = " + r.compareAndSet("b", "c"));
+        System.out.println("ref value = " + r.get());
+        System.out.println("ref updateAndGet = " + r.updateAndGet(s -> s + "!"));
+    }
+}

--- a/tests/test_data/ForkJoinExamples.java
+++ b/tests/test_data/ForkJoinExamples.java
@@ -1,0 +1,189 @@
+package samples.concurrency.forkjoin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.RecursiveAction;
+import java.util.concurrent.RecursiveTask;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+/**
+ * Exercises the ForkJoin framework and parallel streams. Every result is deterministic regardless of
+ * how work is scheduled across pool workers, so the expected output is stable.
+ *
+ * The stress loop and nested-parallelism cases deliberately spin up many pool workers that park
+ * and must be woken to pick up work: if worker wake-up signalling regresses the pool deadlocks and
+ * this program hangs instead of finishing, which is exactly what the test guards against.
+ */
+public class ForkJoinExamples {
+    public static void main(String[] args) throws Exception {
+        recursiveTaskSum();
+        recursiveActionDouble();
+        customPoolInvoke();
+        invokeAllSubtasks();
+        parallelStreamReduce();
+        parallelStreamCollect();
+        nestedParallelism();
+        stressLoop();
+        System.out.println("DONE");
+    }
+
+    /** Divide-and-conquer sum via {@link RecursiveTask#fork()}/{@link RecursiveTask#join()}. */
+    static final class SumTask extends RecursiveTask<Long> {
+        private final long[] a;
+        private final int lo;
+        private final int hi;
+
+        SumTask(long[] a, int lo, int hi) {
+            this.a = a;
+            this.lo = lo;
+            this.hi = hi;
+        }
+
+        @Override
+        protected Long compute() {
+            if (hi - lo <= 500) {
+                long s = 0;
+                for (int i = lo; i < hi; i++) {
+                    s += a[i];
+                }
+                return s;
+            }
+            int mid = (lo + hi) >>> 1;
+            SumTask left = new SumTask(a, lo, mid);
+            left.fork();
+            long right = new SumTask(a, mid, hi).compute();
+            return left.join() + right;
+        }
+    }
+
+    static void recursiveTaskSum() {
+        long[] a = new long[10_000];
+        for (int i = 0; i < a.length; i++) {
+            a[i] = i + 1;
+        }
+        long total = ForkJoinPool.commonPool().invoke(new SumTask(a, 0, a.length));
+        System.out.println("RecursiveTask sum 1..10000 = " + total);
+    }
+
+    /** In-place transform via {@link RecursiveAction} and {@link ForkJoinTask#invokeAll}. */
+    static final class DoubleAction extends RecursiveAction {
+        private final int[] a;
+        private final int lo;
+        private final int hi;
+
+        DoubleAction(int[] a, int lo, int hi) {
+            this.a = a;
+            this.lo = lo;
+            this.hi = hi;
+        }
+
+        @Override
+        protected void compute() {
+            if (hi - lo <= 500) {
+                for (int i = lo; i < hi; i++) {
+                    a[i] *= 2;
+                }
+                return;
+            }
+            int mid = (lo + hi) >>> 1;
+            invokeAll(new DoubleAction(a, lo, mid), new DoubleAction(a, mid, hi));
+        }
+    }
+
+    static void recursiveActionDouble() {
+        int[] a = new int[8_000];
+        Arrays.fill(a, 1);
+        ForkJoinPool.commonPool().invoke(new DoubleAction(a, 0, a.length));
+        long sum = 0;
+        for (int v : a) {
+            sum += v;
+        }
+        System.out.println("RecursiveAction doubled sum = " + sum);
+    }
+
+    static void customPoolInvoke() throws Exception {
+        ForkJoinPool pool = new ForkJoinPool(3);
+        try {
+            long[] a = new long[5_000];
+            Arrays.fill(a, 1L);
+            long r = pool.invoke(new SumTask(a, 0, a.length));
+            System.out.println("Custom pool sum = " + r + ", parallelism = " + pool.getParallelism());
+        } finally {
+            pool.shutdown();
+            pool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    static void invokeAllSubtasks() {
+        long[] a = new long[6_000];
+        Arrays.fill(a, 2L);
+        List<SumTask> tasks =
+                List.of(
+                        new SumTask(a, 0, 2_000),
+                        new SumTask(a, 2_000, 4_000),
+                        new SumTask(a, 4_000, 6_000));
+        ForkJoinTask.invokeAll(tasks);
+        long total = 0;
+        for (SumTask t : tasks) {
+            total += t.join();
+        }
+        System.out.println("invokeAll sum = " + total);
+    }
+
+    static void parallelStreamReduce() {
+        long sum = LongStream.rangeClosed(1, 100_000).parallel().sum();
+        System.out.println("parallel LongStream sum = " + sum);
+        int product = IntStream.rangeClosed(1, 12).boxed().parallel().reduce(1, (x, y) -> x * y);
+        System.out.println("parallel product 1..12 = " + product);
+    }
+
+    static void parallelStreamCollect() {
+        List<Integer> evens =
+                IntStream.range(0, 20_000).parallel().filter(n -> n % 2 == 0).boxed()
+                        .collect(Collectors.toList());
+        System.out.println(
+                "parallel evens: count = "
+                        + evens.size()
+                        + ", first = "
+                        + evens.get(0)
+                        + ", last = "
+                        + evens.get(evens.size() - 1));
+        Map<Boolean, Long> partitioned =
+                IntStream.range(0, 10_000).parallel().boxed()
+                        .collect(Collectors.partitioningBy(n -> n % 3 == 0, Collectors.counting()));
+        System.out.println(
+                "parallel partition %3: divisible = "
+                        + partitioned.get(true)
+                        + ", rest = "
+                        + partitioned.get(false));
+    }
+
+    /** Nested parallelism: each element of an outer parallel stream runs its own parallel reduce. */
+    static void nestedParallelism() {
+        long total =
+                IntStream.rangeClosed(1, 50).parallel()
+                        .mapToLong(k -> LongStream.rangeClosed(1, 1_000).parallel().sum())
+                        .sum();
+        System.out.println("nested parallel total = " + total);
+    }
+
+    /** Repeats a parallel reduction many times to stress pool worker wake-up under contention. */
+    static void stressLoop() {
+        long expected = LongStream.rangeClosed(1, 50_000).sum();
+        int iterations = 40;
+        boolean consistent = true;
+        for (int i = 0; i < iterations; i++) {
+            long s = LongStream.rangeClosed(1, 50_000).parallel().map(x -> x).sum();
+            if (s != expected) {
+                consistent = false;
+            }
+        }
+        System.out.println("stress loop " + iterations + " iterations consistent = " + consistent);
+    }
+}

--- a/tests/test_data/VarHandleCasExamples.java
+++ b/tests/test_data/VarHandleCasExamples.java
@@ -1,0 +1,52 @@
+package samples.concurrency.varhandle;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+/**
+ * Directly exercises {@link VarHandle} {@code compareAndSet} / {@code compareAndExchange} /
+ * {@code weakCompareAndSet} for {@code int} and reference instance fields (the field-instance CAS
+ * branches the atomics test only reaches indirectly).
+ *
+ * <p>Boolean fields are intentionally excluded: the JDK routes {@code compareAndSetBoolean} through
+ * word-masked {@code compareAndSetByte}, which is incompatible with this VM's slot-index field
+ * offsets, so boolean-field CAS is not reliable here.
+ */
+public class VarHandleCasExamples {
+    int i = 10;
+    String s = "a";
+
+    private static final VarHandle I;
+    private static final VarHandle S;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            I = lookup.findVarHandle(VarHandleCasExamples.class, "i", int.class);
+            S = lookup.findVarHandle(VarHandleCasExamples.class, "s", String.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        VarHandleCasExamples o = new VarHandleCasExamples();
+
+        System.out.println("int compareAndSet ok = " + I.compareAndSet(o, 10, 20));
+        System.out.println("int compareAndExchange witness = " + (int) I.compareAndExchange(o, 20, 30));
+        System.out.println("int compareAndExchange fail witness = " + (int) I.compareAndExchange(o, 999, 40));
+        System.out.println("int compareAndExchangeAcquire witness = " + (int) I.compareAndExchangeAcquire(o, 30, 40));
+        System.out.println("int compareAndExchangeRelease witness = " + (int) I.compareAndExchangeRelease(o, 40, 50));
+        System.out.println("int weakCompareAndSet = " + I.weakCompareAndSet(o, 50, 60));
+        System.out.println("int weakCompareAndSetPlain = " + I.weakCompareAndSetPlain(o, 60, 70));
+        System.out.println("int weakCompareAndSetAcquire = " + I.weakCompareAndSetAcquire(o, 70, 80));
+        System.out.println("int weakCompareAndSetRelease = " + I.weakCompareAndSetRelease(o, 80, 90));
+        System.out.println("int value = " + o.i);
+
+        System.out.println("ref compareAndSet ok = " + S.compareAndSet(o, "a", "b"));
+        System.out.println("ref compareAndExchange witness = " + (String) S.compareAndExchange(o, "b", "c"));
+        System.out.println("ref compareAndExchange fail witness = " + (String) S.compareAndExchange(o, "zzz", "d"));
+        System.out.println("ref weakCompareAndSet = " + S.weakCompareAndSet(o, "c", "d"));
+        System.out.println("ref value = " + o.s);
+    }
+}


### PR DESCRIPTION
An intermittent deadlock in parallel streams (~25% on the streams sample, ~100% under sustained parallel work) traced to ForkJoinPool coordination words that could not be updated: the JDK pool relies on native CAS methods this VM did not implement, so signalWork never unparked a worker (all workers plus the submitter parked in Unsafe.park, zero unparks issued).

Add the missing primitives:
- Unsafe.compareAndExchangeInt / compareAndExchangeReference (only ...Long existed); refactor the int CAS into a shared compare_and_x_int returning (swapped, witness).
- VarHandle.compareAndSet for the int (e.g. ForkJoinTask.status) and boolean field-instance handles.
- VarHandle.compareAndExchange (references, ints) and weakCompareAndSet (implemented as a strong CAS, which satisfies the weak contract).

With these, the pool is healthy under true indefinite std::thread::park() (verified 0 hangs across StreamExamples 40x, a parallel stress loop 10x, and ForkJoinExamples 10x).

Boolean-field compareAndExchange is deliberately omitted: this VM's field offsets are slot indices, incompatible with the JDK's word-masked compareAndSetByte path, so boolean-field CAS can corrupt a neighbouring field. Failing fast beats silent corruption; the boolean compareAndSet branch is kept (ForkJoinPool needs it and its field is safe) with a note.

Tests (all matched against real java):
- should_support_fork_join_framework: RecursiveTask/RecursiveAction/custom & common pools, invokeAll, parallel streams, nested parallelism, and a 40-iteration parallel stress loop that hangs on a coordination regression.
- should_support_atomic_compare_and_exchange: AtomicInteger/Long/Reference compareAndSet/compareAndExchange/updateAndGet.
- should_support_var_handle_compare_and_exchange: VarHandle int/reference compareAndSet/compareAndExchange/weakCompareAndSet.